### PR TITLE
Fix: Disable mouse time display on mobile

### DIFF
--- a/src/utils/user-agent.js
+++ b/src/utils/user-agent.js
@@ -1,4 +1,17 @@
-function isIE11() {
+const USER_AGENT = window.navigator && window.navigator.userAgent || '';
+
+const IS_IPAD = (/iPad/i).test(USER_AGENT);
+
+// The Facebook app's UIWebView identifies as both an iPhone and iPad, so
+// to identify iPhones, we need to exclude iPads.
+// http://artsy.github.io/blog/2012/10/18/the-perils-of-ios-user-agent-sniffing/
+const IS_IPHONE = (/iPhone/i).test(USER_AGENT) && !IS_IPAD;
+const IS_IPOD = (/iPod/i).test(USER_AGENT);
+const IS_IOS = IS_IPHONE || IS_IPAD || IS_IPOD;
+
+const IS_ANDROID = (/Android/i).test(USER_AGENT);
+
+const IS_IE11 = (function() {
   let ua = window.navigator.userAgent;
   let trident = ua.indexOf('Trident/');
 
@@ -9,6 +22,6 @@ function isIE11() {
   }
 
   return false;
-}
+}());
 
-module.exports = { isIE11 };
+module.exports = { IS_IPAD, IS_IPHONE, IS_IOS, IS_ANDROID, IS_IE11 };

--- a/src/video-player.js
+++ b/src/video-player.js
@@ -4,7 +4,7 @@ import * as plugins from 'plugins';
 import * as Utils from 'utils';
 import assign from 'utils/assign';
 import { find } from 'utils/find';
-import { isIE11 } from 'utils/user-agent';
+import { IS_IOS, IS_ANDROID, IS_IE11 } from 'utils/user-agent';
 import { startsWith } from 'utils/string';
 import defaults from 'config/defaults';
 import Eventable from 'mixins/eventable';
@@ -105,6 +105,13 @@ const overrideDefaultVideojsComponents = () => {
   children.push('upcomingVideoOverlay');
   children.push('recommendationsOverlay');
 
+  const SeekBar = videojs.getComponent('SeekBar');
+
+  // MouseTimeDisplay tooltips should not be added to a player on mobile devices
+  if (IS_IOS || IS_ANDROID) {
+    SeekBar.prototype.options_.children.splice(1, 1);
+  }
+
   const ControlBar = videojs.getComponent('ControlBar');
   children = ControlBar.prototype.options_.children;
 
@@ -176,7 +183,7 @@ class VideoPlayer extends Utils.mixin(Eventable) {
         this.videojs.addClass(cssClassFromSkin(defaults.skin));
       }
 
-      if (isIE11()) {
+      if (IS_IE11) {
         this.videojs.addClass('cld-ie11');
       }
     };


### PR DESCRIPTION
- [X] Mouse time display over the SeekBar was displaying on mobile devices, which looks weird. This fix disables it.