### PR TITLE
Hide 'upcoming-video' component when loop mode is set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import 'assets/styles/main.scss';
 import cloudinary from 'cloudinary-core';
 import VideoPlayer from 'video-player';
-import videojs from 'video.js';
 import assign from 'utils/assign';
 
 cloudinary.VideoPlayer = VideoPlayer;

--- a/src/plugins/cloudinary/playlist.js
+++ b/src/plugins/cloudinary/playlist.js
@@ -164,10 +164,10 @@ class Playlist {
             this.player().trigger('upcomingvideohide');
             _presentUpcoming.showTriggered = false;
           }
-        } else if (remainingTime <= _presentUpcoming.delay && !_presentUpcoming.showTriggered) {
+        } else if (remainingTime <= _presentUpcoming.delay && !_presentUpcoming.showTriggered && !this.player().loop()) {
           this.player().trigger('upcomingvideoshow');
           _presentUpcoming.showTriggered = true;
-        } else if (remainingTime > _presentUpcoming.delay && _presentUpcoming.showTriggered) {
+        } else if (_presentUpcoming.showTriggered && (remainingTime > _presentUpcoming.delay || this.player().loop())) {
           this.player().trigger('upcomingvideohide');
           _presentUpcoming.showTriggered = false;
         }

--- a/src/video-player.js
+++ b/src/video-player.js
@@ -467,7 +467,7 @@ class VideoPlayer extends Utils.mixin(Eventable) {
       return this.videojs.loop();
     }
 
-    this.videojs.controls(bool);
+    this.videojs.loop(bool);
 
     return this;
   }


### PR DESCRIPTION
- [X] While in playlist and 'loop' mode is set on player, showing 'upcoming-video' to the next video in playlist is useless. This fix hides 'upcoming-video' when 'loop' mode is set on player.