### PR TITLE
remove save-dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "get-size": "^2.0.2",
     "optimize-css-assets-webpack-plugin": "^3.2.0",
     "promise-polyfill": "^6.0.2",
-    "save-dev": "^2.0.0",
     "video.js": "^5.19.0",
     "videojs-contextmenu": "^1.2.2",
     "videojs-contrib-hls": "^5.12.2",


### PR DESCRIPTION
@mikeys typed `npm install save-dev foo` instead of `npm install --save-dev foo`

https://github.com/cloudinary/cloudinary-video-player/pull/13/files