### PR TITLE
CLD-7312-tooltip-logo

### DIFF
--- a/src/plugins/cloudinary/components/cloudinary-button.js
+++ b/src/plugins/cloudinary/components/cloudinary-button.js
@@ -52,7 +52,7 @@ class CloudinaryTooltip extends Component {
       className: 'vjs-cloudinary-tooltip-header',
       href: 'https://cloudinary.com/solutions/video_management',
       target: '_blank',
-      innerHTML: 'Powered By <span class="logo"></span>'
+      innerHTML: 'Powered By <span class="cld-logo"></span>'
     });
     tooltip.appendChild(logo);
 

--- a/src/plugins/cloudinary/components/cloudinary-button.js
+++ b/src/plugins/cloudinary/components/cloudinary-button.js
@@ -52,13 +52,13 @@ class CloudinaryTooltip extends Component {
       className: 'vjs-cloudinary-tooltip-header',
       href: 'https://cloudinary.com/solutions/video_management',
       target: '_blank',
-      innerHTML: 'Powered By <span class="cld-logo"></span>'
+      innerHTML: 'Powered By <span class="vjs-cloudinary-tooltip-logo"></span>'
     });
     tooltip.appendChild(logo);
 
     const fieldsWrpEl = dom.createEl('div', {
       className: 'vjs-cloudinary-tooltip-data-field',
-      innerHTML: '<span class="label">Video ID</span><span class="value">asFgS74o8631fh5</span>'
+      innerHTML: '<span class="vjs-cloudinary-tooltip-label">Video ID</span><span class="vjs-cloudinary-tooltip-value">asFgS74o8631fh5</span>'
     });
     tooltip.appendChild(fieldsWrpEl);
 
@@ -79,7 +79,7 @@ class CloudinaryTooltip extends Component {
         if (Object.prototype.hasOwnProperty.call(info, prop)) {
           const field = dom.createEl('div', {
             className: 'vjs-cloudinary-tooltip-data-field',
-            innerHTML: '<span class="label">' + prop + '</span><span class="value">' + info[prop] + '</span>'
+            innerHTML: '<span class="vjs-cloudinary-tooltip-label">' + prop + '</span><span class="vjs-cloudinary-tooltip-value">' + info[prop] + '</span>'
           });
           fieldsWrp.appendChild(field);
         }

--- a/src/plugins/cloudinary/components/cloudinary-button.scss
+++ b/src/plugins/cloudinary/components/cloudinary-button.scss
@@ -56,7 +56,7 @@ button.vjs-cloudinary-button {
     text-decoration: none;
     color: inherit;
 
-    .cld-logo {
+    .vjs-cloudinary-tooltip-logo {
       background: url("../../../assets/icons/cloudinary_logo_for_white_bg.svg") no-repeat;
       display: inline-block;
       height: 35px;
@@ -70,7 +70,7 @@ button.vjs-cloudinary-button {
     font-weight: 300;
     margin-bottom: 1em;
 
-    .label {
+    .vjs-cloudinary-tooltip-label {
       display: inline-block;
       width: 44%;
       max-width: 120px;

--- a/src/plugins/cloudinary/components/cloudinary-button.scss
+++ b/src/plugins/cloudinary/components/cloudinary-button.scss
@@ -56,7 +56,7 @@ button.vjs-cloudinary-button {
     text-decoration: none;
     color: inherit;
 
-    .logo {
+    .cld-logo {
       background: url("../../../assets/icons/cloudinary_logo_for_white_bg.svg") no-repeat;
       display: inline-block;
       height: 35px;
@@ -84,7 +84,7 @@ button.vjs-cloudinary-button {
       background-image: url("../../../assets/icons/arrow-left-white.svg");
     }
 
-    .vjs-cloudinary-tooltip-header .logo {
+    .vjs-cloudinary-tooltip-header .cld-logo {
       background-image: url("../../../assets/icons/cloudinary_logo_for_dark_bg.svg");
     }
   }

--- a/src/plugins/cloudinary/components/cloudinary-button.scss
+++ b/src/plugins/cloudinary/components/cloudinary-button.scss
@@ -84,7 +84,7 @@ button.vjs-cloudinary-button {
       background-image: url("../../../assets/icons/arrow-left-white.svg");
     }
 
-    .vjs-cloudinary-tooltip-header .cld-logo {
+    .vjs-cloudinary-tooltip-logo {
       background-image: url("../../../assets/icons/cloudinary_logo_for_dark_bg.svg");
     }
   }


### PR DESCRIPTION
There was no issue with the actual player styles.
We just needed more specific class names.
Now using a global namespace of `vjs-cloudinary-COMPONENT-ELEMENT `.