### PR TITLE
CLD-7899-present-Upcoming-option

### DIFF
--- a/src/plugins/cloudinary/components/upcoming-video-overlay.js
+++ b/src/plugins/cloudinary/components/upcoming-video-overlay.js
@@ -12,7 +12,7 @@ class UpcomingVideoOverlay extends ClickableComponent {
     super(player, ...args);
 
     const show = () => {
-      if (this.player().ima && this.player().ima.getAdsManager()) {
+      if (typeof this.player().ima === 'object' && this.player().ima.getAdsManager()) {
         if (!this.player().ima.getAdsManager().getCurrentAd() || this.player().ima.getAdsManager().getCurrentAd().isLinear()) {
           this.addClass('vjs-upcoming-video-show');
         }


### PR DESCRIPTION
This fixes
![image](https://user-images.githubusercontent.com/346835/40587208-b5daa00e-61d4-11e8-852b-305ebe639303.png)

in players without ads.
`ima` is not initialized so `getAdManager` doesn’t exist.
in this scenario `this.player().ima` is actually a function, this is why it throws the error