### PR TITLE
Version release tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build-all": "npm run clean && npm run build && npm run build-light && npm run build-minified && npm run build-minified-light",
     "precommit": "eslint src",
     "preversion": "npm run build-all",
-    "deploy:edge": "npm version prerelease && npm publish --tag edge && git push origin master --follow-tags"
+    "version-prerelease": "npm version $(node -e \"version = require('./package.json').version; semver = require('semver'); console.log(semver.inc(version, 'prerelease', undefined, 'edge'))\")",
+    "deploy:edge": "npm run version-prerelease && npm publish --tag edge && git push origin master --follow-tags"
   },
   "author": "Cloudinary",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "build-all": "npm run clean && npm run build && npm run build-light && npm run build-minified && npm run build-minified-light",
     "precommit": "eslint src",
     "preversion": "npm run build-all",
-    "version-prerelease": "npm version $(node -e \"version = require('./package.json').version; semver = require('semver'); console.log(semver.inc(version, 'prerelease', undefined, 'edge'))\")",
-    "deploy:edge": "npm run version-prerelease && npm publish --tag edge && git push origin master --follow-tags"
+    "predeploy": "npm run build-all",
+    "deploy": "node webpack/deploy.js"
   },
   "author": "Cloudinary",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "analyze": "NODE_ENV=production webpack --config webpack/minified.config.js --json | webpack-bundle-size-analyzer",
     "build-all": "npm run clean && npm run build && npm run build-light && npm run build-minified && npm run build-minified-light",
     "precommit": "eslint src",
-    "preversion": "npm run build-all",
     "predeploy": "npm run build-all",
-    "deploy": "node webpack/deploy.js"
+    "deploy": "node webpack/deploy.js",
+    "postdeploy": "git push origin master --follow-tags"
   },
   "author": "Cloudinary",
   "license": "MIT",

--- a/webpack/deploy.js
+++ b/webpack/deploy.js
@@ -1,0 +1,15 @@
+const semver = require('semver');
+const { execSync } = require('child_process');
+
+const CURRENT_VERSION = require('../package.json').version;
+
+const nextEdgeVersion = () => semver.inc(CURRENT_VERSION, 'prerelease', undefined, 'edge');
+const nextStableVersion = () => semver.inc(CURRENT_VERSION, 'patch');
+const nextVersion = () => {
+  const tag = process.argv[2];
+  return (tag === 'edge') ? nextEdgeVersion() : nextStableVersion();
+};
+
+const cmd = `npm version ${nextVersion()}`;
+
+execSync(cmd);

--- a/webpack/deploy.js
+++ b/webpack/deploy.js
@@ -8,6 +8,8 @@ const nextEdgeVersion = () => semver.inc(CURRENT_VERSION, 'prerelease', undefine
 const nextStableVersion = () => semver.inc(CURRENT_VERSION, 'patch');
 const nextVersion = (tag) => (tag === 'edge') ? nextEdgeVersion() : nextStableVersion();
 
+const versionCmd = (tag) => `npm version ${nextVersion(tag)}`;
+
 const publishCmd = (tag) => {
   let cmd = 'npm publish';
 
@@ -17,8 +19,6 @@ const publishCmd = (tag) => {
 
   return cmd;
 };
-
-const versionCmd = (tag) => `npm version ${nextVersion(tag)}`;
 
 const extractTag = () => {
   let tag = process.argv[2];

--- a/webpack/deploy.js
+++ b/webpack/deploy.js
@@ -28,7 +28,7 @@ const extractTag = () => {
   }
 
   if (!VALID_TAGS.find((t) => t === tag)) {
-    throw Error.new(`Invalid tag ${tag}. Valid tags are: ${VALID_TAGS.join(', ')}`);
+    throw new Error(`Invalid tag ${tag}. Valid tags are: ${VALID_TAGS.join(', ')}`);
   }
 
   return tag;
@@ -37,6 +37,6 @@ const extractTag = () => {
 const tag = extractTag();
 const cmd = `${versionCmd(tag)} && ${publishCmd(tag)}`;
 
-console.log(`Executing ${cmd}...`);
+console.log(`Executing: "${cmd}" ...`);
 
-// execSync(cmd);
+execSync(cmd);

--- a/webpack/deploy.js
+++ b/webpack/deploy.js
@@ -12,4 +12,6 @@ const nextVersion = () => {
 
 const cmd = `npm version ${nextVersion()}`;
 
+console.log(`Executing ${cmd}...`);
+
 execSync(cmd);

--- a/webpack/deploy.js
+++ b/webpack/deploy.js
@@ -2,16 +2,41 @@ const semver = require('semver');
 const { execSync } = require('child_process');
 
 const CURRENT_VERSION = require('../package.json').version;
+const VALID_TAGS = ['edge', 'stable'];
 
 const nextEdgeVersion = () => semver.inc(CURRENT_VERSION, 'prerelease', undefined, 'edge');
 const nextStableVersion = () => semver.inc(CURRENT_VERSION, 'patch');
-const nextVersion = () => {
-  const tag = process.argv[2];
-  return (tag === 'edge') ? nextEdgeVersion() : nextStableVersion();
+const nextVersion = (tag) => (tag === 'edge') ? nextEdgeVersion() : nextStableVersion();
+
+const publishCmd = (tag) => {
+  let cmd = 'npm publish';
+
+  if (tag !== 'stable') {
+    cmd += ' --tag edge';
+  }
+
+  return cmd;
 };
 
-const cmd = `npm version ${nextVersion()}`;
+const versionCmd = (tag) => `npm version ${nextVersion(tag)}`;
+
+const extractTag = () => {
+  let tag = process.argv[2];
+
+  if (!tag) {
+    return 'edge';
+  }
+
+  if (!VALID_TAGS.find((t) => t === tag)) {
+    throw Error.new(`Invalid tag ${tag}. Valid tags are: ${VALID_TAGS.join(', ')}`);
+  }
+
+  return tag;
+};
+
+const tag = extractTag();
+const cmd = `${versionCmd(tag)} && ${publishCmd(tag)}`;
 
 console.log(`Executing ${cmd}...`);
 
-execSync(cmd);
+// execSync(cmd);

--- a/webpack/deploy.js
+++ b/webpack/deploy.js
@@ -14,7 +14,7 @@ const publishCmd = (tag) => {
   let cmd = 'npm publish';
 
   if (tag !== 'stable') {
-    cmd += ' --tag edge';
+    cmd += ` --tag ${tag}`;
   }
 
   return cmd;


### PR DESCRIPTION
## Tooling for making release process a bit easier:
- `npm run deploy` for `stable` version release
- `npm run deploy -- edge` for `edge` version release

### Versioning:
Assuming `version: 1.0.3-edge.4`:
- `npm run deploy` will result a version bump to `1.0.3`
- `npm run deploy -- edge` will result a version bump to `1.0.3-edge.5`

Assuming `version: 1.0.3`:
- `npm run deploy` will result a version bump to `1.0.4`
- `npm run deploy -- edge` will result a version bump to `1.0.4-edge.0`
