### PR TITLE
CLD-4065-poster-before-ad

### DIFF
--- a/src/assets/styles/videojs-ima.scss
+++ b/src/assets/styles/videojs-ima.scss
@@ -3,8 +3,11 @@
     line-height: 1.7;
   }
 
-  &.vjs-ad-loading > video {
-    opacity: 0;
+  &.vjs-ad-loading {
+    > video,
+    > .vjs-poster {
+      opacity: 0;
+    }
   }
 }
 


### PR DESCRIPTION
We already handled the case of the video visible while ads are loading.
This PR also hides the video poster that was showing while the ad was loading.