### PR TITLE
APPS-2793-responsive-poster

### DIFF
--- a/src/plugins/cloudinary/index.js
+++ b/src/plugins/cloudinary/index.js
@@ -271,8 +271,18 @@ class CloudinaryContext extends mixin(Playlistable) {
       }
 
       opts.transformation = getCloudinaryInstanceOf(cloudinary.Transformation, opts.transformation || {});
-      if (this.player.width() > 0 && this.player.height() > 0) {
-        opts.transformation.width(this.player.width()).height(this.player.height()).crop('limit');
+
+      // Set poster dimensions to player actual size.
+      // (unless they were explicitly set via `posterOptions`)
+      const playerEl = this.player.el();
+      if (playerEl && !opts.transformation.getValue('width') && !opts.transformation.getValue('height')) {
+
+        const roundUp100 = (val) => 100 * Math.ceil(val / 100);
+
+        opts.transformation
+          .width(roundUp100(playerEl.clientWidth))
+          .height(roundUp100(playerEl.clientHeight))
+          .crop('limit');
       }
 
       return opts;


### PR DESCRIPTION
This builds on top of functionality that was already in place -

`Set the poster dimensions to player dimensions if those are specified` - this worked but completely ignored fluidity and actual player size.

After this change, we set poster dimensions (rounded to 100px) whenever we have a player size and as long as those were not specified explicitly.