### PR TITLE
APPS-4585-remove-dash-from-light

### DIFF
--- a/docs/adaptive-streaming.html
+++ b/docs/adaptive-streaming.html
@@ -43,11 +43,11 @@
         }
       );
       playerHlsH265.source(
-              'sea_turtle',
-              {
-                sourceTypes: ['hls/h265'],
-                info: {title: 'HLS 265'}
-              }
+        'sea_turtle',
+        {
+          sourceTypes: ['hls/h265'],
+          info: {title: 'HLS 265'}
+        }
       );
       playerDash.source(
         'sea_turtle',
@@ -58,25 +58,25 @@
         }
       );
       playerDashVp9.source(
-              'sea_turtle',
-              {
-                sourceTypes: ['dash/vp9'],
-                info: {title: 'MPEG-DASH vp9'}
-              }
+        'sea_turtle',
+        {
+          sourceTypes: ['dash/vp9'],
+          info: {title: 'MPEG-DASH vp9'}
+        }
       );
       playerHlsNoCodec.source(
-              'sea_turtle',
-              {
-                sourceTypes: ['hls'],
-                info: {title: 'HLS'}
-              }
+        'sea_turtle',
+        {
+          sourceTypes: ['hls'],
+          info: {title: 'HLS'}
+        }
       );
       playerDashNoCodec.source(
-              'sea_turtle',
-              {
-                sourceTypes: ['dash'],
-                info: {title: 'MPEG-DASH'}
-              }
+        'sea_turtle',
+        {
+          sourceTypes: ['dash'],
+          info: {title: 'MPEG-DASH'}
+        }
       );
 
       playerHls.on('qualitychanged', function(data) {
@@ -132,14 +132,15 @@
       ></video>
       <span id="info-hls"></span>
     </div>
+
     <div class="video-container mb-4">
       <h4>HLS 265</h4>
       <video
-              id="example-player-hls-h265"
-              controls
-              muted
-              width="500"
-              class="cld-video-player"
+        id="example-player-hls-h265"
+        controls
+        muted
+        width="500"
+        class="cld-video-player"
       ></video>
       <span id="info-hls-h265"></span>
     </div>
@@ -156,27 +157,29 @@
       ></video>
       <span id="info-dash"></span>
     </div>
+
     <div class="video-container mb-4">
       <h4>MPEG-DASH vp9</h4>
       <video
-              id="example-player-dash-vp9"
-              playsinline
-              controls
-              muted
-              width="500"
-              class="cld-video-player"
+        id="example-player-dash-vp9"
+        playsinline
+        controls
+        muted
+        width="500"
+        class="cld-video-player"
       ></video>
       <span id="info-dash-vp9"></span>
     </div>
+
     <div class="video-container mb-4">
       <h4>HLS no codec</h4>
       <video
-              id="example-player-hls-no-codec"
-              playsinline
-              controls
-              muted
-              width="500"
-              class="cld-video-player"
+        id="example-player-hls-no-codec"
+        playsinline
+        controls
+        muted
+        width="500"
+        class="cld-video-player"
       ></video>
       <span id="info-hls-no-codec"></span>
     </div>
@@ -184,19 +187,15 @@
     <div class="video-container mb-4">
       <h4>DASH no codec</h4>
       <video
-              id="example-player-dash-no-codec"
-              playsinline
-              controls
-              muted
-              width="500"
-              class="cld-video-player"
+        id="example-player-dash-no-codec"
+        playsinline
+        controls
+        muted
+        width="500"
+        class="cld-video-player"
       ></video>
       <span id="info-dash-no-codec"></span>
     </div>
-
-
-
-
 
     <p class="mt-4">
       <a href="https://cloudinary.com/documentation/video_player_hls_dash">Adaptive streaming documentation</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,6 +24,14 @@
 
       player = cld.videoPlayer('player');
 
+      player.source(
+        'sea_turtle',
+        {
+          sourceTypes: ['dash/vp9'],
+          info: {title: 'MPEG-DASH vp9'}
+        }
+      );
+
     }, false);
   </script>
 
@@ -38,7 +46,6 @@
       controls
       muted
       class="cld-video-player cld-video-player-skin-dark cld-fluid"
-      data-cld-source='{ "publicId": "sea_turtle", "info": { "title": "Sea turtle", "subtitle": "Short movie about a sea turtle" } }'
     ></video>
 
     <p class="mt-4">

--- a/src/plugins/cloudinary/index.js
+++ b/src/plugins/cloudinary/index.js
@@ -255,7 +255,6 @@ class CloudinaryContext extends mixin(Playlistable) {
         }
         return true;
       });
-      console.log(_sources);
       this.player.src(_sources);
 
       _lastSource = src;

--- a/src/plugins/dash/index.js
+++ b/src/plugins/dash/index.js
@@ -1,0 +1,26 @@
+import videojs from 'video.js';
+import djs from 'dashjs';
+// eslint-disable-next-line no-unused-vars
+import Html5DashJS from 'plugins/dash/videojs-dash';
+
+export default function dashPlugin() {
+
+  const dashInit = (player, mediaPlayer) => {
+    // eslint-disable-next-line new-cap
+    mediaPlayer = djs.MediaPlayer().create();
+    let settings = {
+      streaming: {
+        liveDelayFragmentCount: null
+      }
+    };
+    mediaPlayer.updateSettings(settings);
+    mediaPlayer.on(djs.MediaPlayer.events.PLAYBACK_STALLED, (a) => {
+      console.log(a);
+      console.log('stalled');
+    });
+  };
+
+  // Triggered on 'beforeinitialize'
+  videojs.Html5DashJS.hook('beforeinitialize', dashInit);
+
+}

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,6 +1,7 @@
 // #if (!process.env.WEBPACK_BUILD_LIGHT)
 import 'videojs-contrib-ads';
 import './ima';
+import dashPlugin from './dash';
 import interactive from './interactive-plugin';
 // #endif
 import 'videojs-per-source-behaviors';
@@ -19,6 +20,7 @@ export {
   cloudinary,
   analytics,
   // #if (!process.env.WEBPACK_BUILD_LIGHT)
-  interactive
+  interactive,
+  dashPlugin
   // #endif
 };

--- a/src/video-player.js
+++ b/src/video-player.js
@@ -9,9 +9,11 @@ import Eventable from 'mixins/eventable';
 import ExtendedEvents from 'extended-events';
 import normalizeAttributes from './attributes-normalizer';
 import PlaylistWidget from './components/playlist/playlist-widget';
+// #if (!process.env.WEBPACK_BUILD_LIGHT)
 import djs from 'dashjs';
 // eslint-disable-next-line no-unused-vars
 import Html5DashJS from 'plugins/dash/videojs-dash';
+// #endif
 
 import {
   CLASS_PREFIX,
@@ -173,6 +175,7 @@ overrideDefaultVideojsComponents();
 
 let _allowUsageReport = true;
 
+// #if (!process.env.WEBPACK_BUILD_LIGHT)
 const dashInit = (player, mediaPlayer) => {
   // eslint-disable-next-line new-cap
   mediaPlayer = djs.MediaPlayer().create();
@@ -187,6 +190,7 @@ const dashInit = (player, mediaPlayer) => {
     console.log('stalled');
   });
 };
+// #endif
 
 class VideoPlayer extends Utils.mixin(Eventable) {
   constructor(elem, options, ready) {
@@ -423,7 +427,9 @@ class VideoPlayer extends Utils.mixin(Eventable) {
 
     // Handle play button options
     Utils.playButton(elem, _vjs_options);
+    // #if (!process.env.WEBPACK_BUILD_LIGHT)
     videojs.Html5DashJS.hook('beforeinitialize', dashInit);
+    // #endif
 
     this.videojs = videojs(elem, _vjs_options);
 

--- a/src/video-player.js
+++ b/src/video-player.js
@@ -9,11 +9,6 @@ import Eventable from 'mixins/eventable';
 import ExtendedEvents from 'extended-events';
 import normalizeAttributes from './attributes-normalizer';
 import PlaylistWidget from './components/playlist/playlist-widget';
-// #if (!process.env.WEBPACK_BUILD_LIGHT)
-import djs from 'dashjs';
-// eslint-disable-next-line no-unused-vars
-import Html5DashJS from 'plugins/dash/videojs-dash';
-// #endif
 
 import {
   CLASS_PREFIX,
@@ -174,23 +169,6 @@ const overrideDefaultVideojsComponents = () => {
 overrideDefaultVideojsComponents();
 
 let _allowUsageReport = true;
-
-// #if (!process.env.WEBPACK_BUILD_LIGHT)
-const dashInit = (player, mediaPlayer) => {
-  // eslint-disable-next-line new-cap
-  mediaPlayer = djs.MediaPlayer().create();
-  let settings = {
-    streaming: {
-      liveDelayFragmentCount: null
-    }
-  };
-  mediaPlayer.updateSettings(settings);
-  mediaPlayer.on(djs.MediaPlayer.events.PLAYBACK_STALLED, (a) => {
-    console.log(a);
-    console.log('stalled');
-  });
-};
-// #endif
 
 class VideoPlayer extends Utils.mixin(Eventable) {
   constructor(elem, options, ready) {
@@ -427,9 +405,11 @@ class VideoPlayer extends Utils.mixin(Eventable) {
 
     // Handle play button options
     Utils.playButton(elem, _vjs_options);
-    // #if (!process.env.WEBPACK_BUILD_LIGHT)
-    videojs.Html5DashJS.hook('beforeinitialize', dashInit);
-    // #endif
+
+    // Dash plugin - available in full (not light) build only
+    if (plugins.dashPlugin) {
+      plugins.dashPlugin();
+    }
 
     this.videojs = videojs(elem, _vjs_options);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3852,10 +3852,10 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-cloudinary-core@^2.10.2:
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/cloudinary-core/-/cloudinary-core-2.10.2.tgz#966bdd7e4545b83cf8253a2454a5f87fac673d6e"
-  integrity sha512-1JvgOCMRTke5S7/Nps8GW8gqmxq3unB4e6kDePuyG7VOFXrhFIOT0q9REiPBfFnHhkuyNYWLySSFaNIAZocOBw==
+cloudinary-core@^2.10.3:
+  version "2.10.3"
+  resolved "https://registry.yarnpkg.com/cloudinary-core/-/cloudinary-core-2.10.3.tgz#57706cf966bc627706ad8e1ee78db478ea69a6c5"
+  integrity sha512-uI7jASEcfjYBdoTb2uj4wgTB0cWPDwrQV4paYFOgEdU22z74eeJ1zI83ew2kuNnXBnbuPZFt310H329UfiHG2w==
 
 co@^4.6.0:
   version "4.6.0"


### PR DESCRIPTION
This fixes the `light` version logic so that it does not include Dash. while still keeping the fix to APPS-4585 by @yaniv-li 

I created a sandbox with both version for testing here: https://codesandbox.io/s/amazing-https-bzskq?file=/index.html