### PR TITLE
APPS-5025-poster-options

### DIFF
--- a/docs/_template.html
+++ b/docs/_template.html
@@ -23,7 +23,7 @@
 
       var cld = cloudinary.Cloudinary.new({ cloud_name: 'demo' });
 
-      var player = cld.videoPlayer('player', {
+      player = cld.videoPlayer('player', {
         publicId: 'snow_horses',
         info: { title: 'Snow Horses', subtitle: 'A movie about horses' },
       });
@@ -70,7 +70,7 @@
         var cld = cloudinary.Cloudinary.new({ cloud_name: 'demo' });
 
         // Initialize player
-        var player = cld.videoPlayer('player');
+        player = cld.videoPlayer('player');
 
         // Define source
         var source = { publicId: 'snow_horses', info: { title: 'Snow Horses', subtitle: 'A movie about horses' } };

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,6 +63,7 @@
       <li><a href="./floating-player.html">Floating Player</a></li>
       <li><a href="./colors.html">Colors API</a></li>
       <li><a href="./ui-config.html">Display Configurations</a></li>
+      <li><a href="./poster.html">Poster Options</a></li>
       <li><a href="./subtitles-and-captions.html">Subtitles & Captions</a></li>
       <li><a href="./custom-cld-errors.html">Custom Errors</a></li>
       <li><a href="./codec-fallback.html">Codec and Fallback</a></li>

--- a/docs/poster.html
+++ b/docs/poster.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Cloudinary Video Player</title>
+  <link href="https://cloudinary-res.cloudinary.com/image/asset/favicon-32x32-2991a47c2caa80211bf2dbf3f29317c8.png"
+    rel="icon" sizes="32x32" type="image/png">
+
+  <!--
+    We're loading scripts & style dynamically for development/testing.
+    Real-world usage would look like this:
+
+    <link rel="stylesheet" href="https://unpkg.com/cloudinary-video-player/dist/cld-video-player.min.css">
+
+    <script src="https://unpkg.com/cloudinary-core/cloudinary-core-shrinkwrap.js"></script>
+    <script src="https://unpkg.com/cloudinary-video-player/dist/cld-video-player.min.js"></script>
+
+  -->
+
+  <script type="text/javascript" src="./scripts.js"></script>
+
+  <script type="text/javascript">
+    window.addEventListener('load', function () {
+
+      var cld = cloudinary.Cloudinary.new({ cloud_name: 'demo' });
+
+      player1 = cld.videoPlayer('player-image-poster', {
+        publicId: 'snow_horses'
+      });
+
+      player2 = cld.videoPlayer('player-frame-0', {
+        publicId: 'snow_horses',
+        posterOptions: {
+          transformation: {
+            startOffset: "0"
+          }
+        }
+      });
+
+      player3 = cld.videoPlayer('player-poster-options', {
+        publicId: 'snow_horses'
+      });
+
+    }, false);
+  </script>
+
+</head>
+
+<body>
+  <div class="container p-4 col-12 col-md-9 col-xl-6">
+    <nav class="nav mb-2">
+      <a href="./index.html">&#60;&#60; Back to examples index</a>
+    </nav>
+    <h1>Cloudinary Video Player</h1>
+    <h3 class="mb-4">Advanced Poster Configurations</h3>
+
+    <div class="video-container mb-4">
+      <h4>Custom image poster</h4>
+      <video
+        id="player-image-poster"
+        playsinline
+        controls
+        class="cld-video-player cld-fluid"
+        data-cld-transformation='{ "effect": ["saturation:-100"] }'
+        data-cld-poster-options='{ "publicId": "sample", "effect": ["saturation:-100"] }'
+      ></video>
+    </div>
+
+    <div class="video-container mb-4">
+      <h4>Specific frame poster</h4>
+      <video
+        id="player-frame-0"
+        playsinline
+        controls
+        class="cld-video-player cld-fluid"
+      ></video>
+    </div>
+
+    <div class="video-container mb-4">
+      <h4>Poster options transformations-array</h4>
+      <video
+        id="player-poster-options"
+        playsinline
+        controls
+        class="cld-video-player cld-fluid"
+        data-cld-poster-options='{ "transformation": [{"width": "640", "height": "360", "crop": "pad", "effect": "grayscale" },{"overlay":"cloudinary_icon", "width":"300"},{"quality": "auto", "fetch_format": "auto"}] }'
+      ></video>
+    </div>
+
+    <p class="mt-4">
+      <a href="https://cloudinary.com/documentation/video_player_api_reference#posteroptions">Full documentation</a>
+    </p>
+
+    <h3 class="mt-4">Example Code:</h3>
+    <pre>
+      <code class="language-html">
+        &lt;video
+          id="player-image-poster"
+          playsinline
+          controls
+          class="cld-video-player cld-fluid"
+          data-cld-transformation='{ "effect": ["saturation:-100"] }'
+          data-cld-poster-options='{ "publicId": "sample", "effect": ["saturation:-100"] }'
+        &gt;&lt;/video&gt;
+
+        &lt;video
+          id="player-frame-0"
+          playsinline
+          controls
+          class="cld-video-player cld-fluid"
+        &gt;&lt;/video&gt;
+
+        &lt;video
+          id="player-poster-options"
+          playsinline
+          controls
+          class="cld-video-player cld-fluid"
+          data-cld-poster-options='{ "transformation": [{"width": "640", "height": "360", "crop": "pad", "effect": "grayscale" },{"overlay":"cloudinary_icon", "width":"300"},{"quality": "auto", "fetch_format": "auto"}] }'
+        &gt;&lt;/video&gt;
+      </code>
+      <code class="language-javascript">
+        var cld = cloudinary.Cloudinary.new({ cloud_name: 'demo' });
+
+        player1 = cld.videoPlayer('player-image-poster', {
+          publicId: 'snow_horses'
+        });
+
+        player2 = cld.videoPlayer('player-frame-0', {
+          publicId: 'snow_horses',
+          posterOptions: {
+            transformation: {
+              startOffset: "0"
+            }
+          }
+        });
+
+        player3 = cld.videoPlayer('player-poster-options', {
+          publicId: 'snow_horses'
+        });
+      </code>
+    </pre>
+  </div>
+
+  <!-- Bootstrap -->
+  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet"
+    integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+
+  <!-- highlight.js -->
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/solarized-light.min.css">
+  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+
+</body>
+
+</html>

--- a/src/plugins/cloudinary/index.js
+++ b/src/plugins/cloudinary/index.js
@@ -2,7 +2,7 @@ import cloudinary from 'cloudinary-core';
 import mixin from 'utils/mixin';
 import applyWithProps from 'utils/apply-with-props';
 import { sliceAndUnsetProperties } from 'utils/slicing';
-import { getCloudinaryInstanceOf } from 'utils/cloudinary';
+import { getCloudinaryInstanceOf, isKeyInTransformation } from 'utils/cloudinary';
 import assign from 'utils/assign';
 import { normalizeOptions, mergeTransformation, mergeCloudinaryConfig } from './common';
 import Playlistable from './mixins/playlistable';
@@ -274,8 +274,7 @@ class CloudinaryContext extends mixin(Playlistable) {
       // Set poster dimensions to player actual size.
       // (unless they were explicitly set via `posterOptions`)
       const playerEl = this.player.el();
-      if (playerEl && !opts.transformation.getValue('width') && !opts.transformation.getValue('height')) {
-
+      if (playerEl && !isKeyInTransformation(opts.transformation, 'width') && !isKeyInTransformation(opts.transformation, 'height')) {
         const roundUp100 = (val) => 100 * Math.ceil(val / 100);
 
         opts.transformation

--- a/src/plugins/cloudinary/models/video-source.js
+++ b/src/plugins/cloudinary/models/video-source.js
@@ -4,6 +4,7 @@ import { normalizeOptions, isSrcEqual, codecShorthandTrans, codecToSrcTransforma
 import { sliceAndUnsetProperties } from 'utils/slicing';
 import assign from 'utils/assign';
 import { objectToQuerystring } from 'utils/querystring';
+import { isKeyInTransformation } from 'utils/cloudinary';
 
 if (!Array.prototype.find) {
   // eslint-disable-next-line no-extend-native
@@ -71,31 +72,6 @@ const VIDEO_SUFFIX_REMOVAL_PATTERN = RegExp(`\\.(${DEFAULT_VIDEO_SOURCE_TYPES.jo
 
 let objectId = 0;
 const generateId = () => objectId++;
-
-/**
- * Check if key exist in transformation
- * @param transformation
- * @param key
- * @returns true if key exists in transformation, false otherwise
- */
-const isKeyInTransformation = (transformation, key) => {
-  if (!transformation || !key) {
-    return false;
-  }
-
-  // transformation is an array so run this function for each item
-  if (Array.isArray(transformation)) {
-    return !!transformation.find(t => isKeyInTransformation(t, key));
-  }
-
-  // transformation is a Transformation object so use getValue() to check key
-  if (transformation.getValue) {
-    return !!transformation.getValue(key);
-  }
-
-  // transformation is an Object so just check for key existence in object
-  return !!transformation[key];
-};
 
 class VideoSource extends BaseSource {
   constructor(publicId, options = {}) {

--- a/src/utils/cloudinary.js
+++ b/src/utils/cloudinary.js
@@ -98,4 +98,33 @@ function getCloudinaryInstanceOf(Klass, obj) {
   }
 }
 
-export { getCloudinaryInstanceOf, handleCldError };
+/**
+ * Check if key exist in transformation
+ * @param transformation
+ * @param key
+ * @returns true if key exists in transformation, false otherwise
+ */
+const isKeyInTransformation = (transformation, key) => {
+  if (!transformation || !key) {
+    return false;
+  }
+
+  // transformation is an array so run this function for each item
+  if (Array.isArray(transformation)) {
+    return !!transformation.find(t => isKeyInTransformation(t, key));
+  }
+
+  // transformation is a Transformation object so use getValue() to check key
+  if (transformation.getValue) {
+    return !!transformation.getValue(key);
+  }
+
+  // transformation is an Object so just check for key existence in object
+  return !!transformation[key];
+};
+
+export {
+  getCloudinaryInstanceOf,
+  handleCldError,
+  isKeyInTransformation
+};

--- a/src/video-player.js
+++ b/src/video-player.js
@@ -179,7 +179,6 @@ class VideoPlayer extends Utils.mixin(Eventable) {
 
     const onReady = () => {
       setExtendedEvents();
-      this.fluid(_options.fluid);
 
       // Load first video (mainly to support video tag 'source' and 'public-id' attributes)
       const source = _options.source || _options.publicId;
@@ -417,6 +416,10 @@ class VideoPlayer extends Utils.mixin(Eventable) {
       this.videojs.volume(0.4);
     }
 
+    if (_options.fluid) {
+      this.fluid(_options.fluid);
+    }
+
     /* global google */
     let loaded = {
       contribAdsLoaded: typeof this.videojs.ads === 'function',
@@ -426,6 +429,7 @@ class VideoPlayer extends Utils.mixin(Eventable) {
     initPlugins(loaded);
     initPlaylistWidget();
     initJumpButtons();
+
     this.videojs.on('error', () => {
       const error = this.videojs.error();
       if (error) {


### PR DESCRIPTION
This PR fixes an issue in v1.4.1 where setting an Array of poster-transformation would cause our fluid-poster logic to fail (https://codesandbox.io/s/spring-water-iyyqe).
- uses `isKeyInTransformation` instead of dirctly checking `opts.transformation.getValue`
- moved `isKeyInTransformation` to `/src/utils/cloudinary`
- moved `this.fluid(_options.fluid)` initialization so it happens a bit sooner