### PR TITLE
fix: calling `contains` on `null` in plugins/cloudinary

### DIFF
--- a/src/plugins/cloudinary/index.js
+++ b/src/plugins/cloudinary/index.js
@@ -280,7 +280,7 @@ class CloudinaryContext extends mixin(Playlistable) {
       let src = data.to;
 
       // When source is cloudinary's
-      if (_lastSource.contains(src)) {
+      if (_lastSource && _lastSource.contains(src)) {
         // If plugin state doesn't have an active VideoSource
         if (!this.source()) {
           // We might have been running a playlist, reset playlist's state.


### PR DESCRIPTION
This fixes an error that is being logged to the console:
> VIDEOJS: ERROR: TypeError: Cannot read property 'contains' of null
    at Player.syncState (index.js:399)
    at HTMLDivElement.data.dispatcher (video.es.js:1939)
    at trigger (video.es.js:2075)
    at Player.trigger$1 (video.es.js:2961)
    at Player.eval (videojs-per-source-behaviors.es.js:314)
    at eval (video.es.js:4666)

`_lastSource` is explicitly set to `null` higher up in the file, so calling `contains` on it causes this error.

Seems to be an easy fix: just ensure it's truthy before running `contains`.