### PR TITLE
CLD-1937-cld-logo-btn fix

### DIFF
--- a/src/components/logoButton/logo-button.scss
+++ b/src/components/logoButton/logo-button.scss
@@ -1,8 +1,9 @@
 // Player Cloudinary button
-a.vjs-cloudinary-button {
-  background: url("../../assets/icons/cloudinary_icon_for_black_bg.svg") no-repeat;
+.vjs-control-bar a.vjs-control.vjs-cloudinary-button {
+  background-image: url("../../assets/icons/cloudinary_icon_for_black_bg.svg");
   background-size: 25px;
   background-position: center;
+  background-repeat: no-repeat;
 
   .cld-video-player-skin-light & {
     background-image: url("../../assets/icons/cloudinary_icon_for_white_bg.svg");


### PR DESCRIPTION
fixes logo button styles when focused:

![image](https://user-images.githubusercontent.com/346835/96448696-78342680-121c-11eb-8200-a810edf87498.png)

probably caused by a VideoJS update