### PR TITLE
fix: APPS-7708 When playing a second HLS video, the player throws an …

### DIFF
--- a/src/plugins/cloudinary/models/video-source.js
+++ b/src/plugins/cloudinary/models/video-source.js
@@ -200,8 +200,8 @@ class VideoSource extends BaseSource {
 
   generateRawSource(url, type) {
     let t = type || url.split('.').pop();
-    const isAdaptive = (['mpd', 'm3u8', 'hls', 'dash'].indexOf(t) !== -1);
-    if (isAdaptive && CONTAINER_MIME_TYPES[t]) {
+    const isAdaptive = CONTAINER_MIME_TYPES[t];
+    if (isAdaptive) {
       type = CONTAINER_MIME_TYPES[t][0];
     } else {
       type = type ? `video/${type}` : null;

--- a/src/plugins/cloudinary/models/video-source.js
+++ b/src/plugins/cloudinary/models/video-source.js
@@ -202,7 +202,7 @@ class VideoSource extends BaseSource {
     let t = type || url.split('.').pop();
     const isAdaptive = (['mpd', 'm3u8', 'hls', 'dash'].indexOf(t) !== -1);
     if (isAdaptive && CONTAINER_MIME_TYPES[t]) {
-      type = CONTAINER_MIME_TYPES[t].pop();
+      type = CONTAINER_MIME_TYPES[t][0];
     } else {
       type = type ? `video/${type}` : null;
     }


### PR DESCRIPTION
Fixed an issue where when playing a second video (HLS), the player would throw an error: 'Uncaught TypeError: Cannot read property 'split' of undefined'