### PR TITLE
Fix type declaration name for videojs option

### DIFF
--- a/types/video-player.d.ts
+++ b/types/video-player.d.ts
@@ -126,7 +126,7 @@ export interface Options {
     ads?: AdsOptions,
     analytics?: boolean,
     allowUsageReport?: boolean,
-    videoJS?: VideoJsPlayerOptions;
+    videojs?: VideoJsPlayerOptions;
 }
 
 /**


### PR DESCRIPTION
I run into an issue where the low-level customization options with Video.js were ignored in TypeScript.

Video.js option names are expected to be all lowercase.

https://github.com/cloudinary/cloudinary-video-player/blob/a013bc009712a44c34a44d922a809e9840f88a45/src/video-player.js#L132-L137

After modifying the type definition name from "videoJS" to "videojs", the Low-level customization option worked correctly in my environment.