### PR TITLE
adding transition to interaction-area item

### DIFF
--- a/src/assets/styles/components/interaction-areas.scss
+++ b/src/assets/styles/components/interaction-areas.scss
@@ -42,7 +42,8 @@ $interaction-area-layout-icon-height: 60px;
       display: inline-flex;
       align-items: center;
       justify-content: center;
-
+      transition: top, left, width, height;
+      transition-timing-function: linear;
 
       &.theme-shadowed {
 

--- a/src/components/interaction-area/interaction-area.const.js
+++ b/src/components/interaction-area/interaction-area.const.js
@@ -25,5 +25,6 @@ export const TEMPLATE_INTERACTION_AREAS_VTT = {
 
 export const INTERACTION_AREA_HAND_ICON = 'https://res.cloudinary.com/prod/image/upload/v1626764643/video-player/interaction-area-hand.svg';
 
-
 export const CLOSE_INTERACTION_AREA_LAYOUT_DELAY = 4500;
+
+export const DEFAULT_INTERACTION_ARE_TRANSITION = 250;

--- a/src/components/interaction-area/interaction-area.utils.js
+++ b/src/components/interaction-area/interaction-area.utils.js
@@ -17,7 +17,7 @@ import { BUTTON_THEME } from '../themeButton/themedButton.const';
 
 const getInteractionAreaItemId = (item, index) => item.id || item.type || `id_${index}`;
 
-export const getInteractionAreaItem = ({ playerOptions, videojsOptions }, item, index, onClick) => {
+export const getInteractionAreaItem = ({ playerOptions, videojsOptions }, item, index, durationTime = 0, onClick) => {
   const defaultColor = getDefaultPlayerColor(videojsOptions);
   const accentColor = playerOptions && playerOptions.colors ? playerOptions.colors.accent : defaultColor.accent;
 
@@ -31,7 +31,8 @@ export const getInteractionAreaItem = ({ playerOptions, videojsOptions }, item, 
       left: `${item.left}%`,
       top: `${item.top}%`,
       width: `${item.width}%`,
-      height: `${item.height}%`
+      height: `${item.height}%`,
+      transitionDuration: `${durationTime}ms`
     },
     event: {
       name: 'click',
@@ -102,7 +103,7 @@ export const setInteractionAreasContainer = (videojs, newInteractionAreasContain
 const getInteractionAreaElementById = (interactionAreasContainer, item, index) => interactionAreasContainer.querySelector(`[data-id=${getInteractionAreaItemId(item, index)}]`);
 
 
-export const updateInteractionAreasItem = (videojs, configs, interactionAreasData, previousInteractionAreasData, onClick) => {
+export const updateInteractionAreasItem = (videojs, configs, interactionAreasData, previousInteractionAreasData, durationTime, onClick) => {
   const interactionAreasContainer = getInteractionAreasContainer(videojs);
 
   forEach(interactionAreasData, (item, index) => {
@@ -116,11 +117,12 @@ export const updateInteractionAreasItem = (videojs, configs, interactionAreasDat
         left: `${item.left}%`,
         top: `${item.top}%`,
         width: `${item.width}%`,
-        height: `${item.height}%`
+        height: `${item.height}%`,
+        transitionDuration: `${durationTime}ms`
       });
       // if the element did not exist before , not in the dom and not in the previous data , it add a new element
     } else if (!isExistItem && !itemElement) {
-      interactionAreasContainer.append(getInteractionAreaItem(configs, item, index, (event) => {
+      interactionAreasContainer.append(getInteractionAreaItem(configs, item, index, durationTime, (event) => {
         onClick({ event, item, index });
       }));
     }

--- a/src/components/interaction-area/interaction-area.utils.js
+++ b/src/components/interaction-area/interaction-area.utils.js
@@ -17,7 +17,7 @@ import { BUTTON_THEME } from '../themeButton/themedButton.const';
 
 const getInteractionAreaItemId = (item, index) => item.id || item.type || `id_${index}`;
 
-export const getInteractionAreaItem = ({ playerOptions, videojsOptions }, item, index, durationTime = 0, onClick) => {
+export const getInteractionAreaItem = ({ playerOptions, videojsOptions }, item, index, durationTime, onClick) => {
   const defaultColor = getDefaultPlayerColor(videojsOptions);
   const accentColor = playerOptions && playerOptions.colors ? playerOptions.colors.accent : defaultColor.accent;
 

--- a/src/video-player.js
+++ b/src/video-player.js
@@ -655,16 +655,16 @@ class VideoPlayer extends Utils.mixin(Eventable) {
     });
   }
 
-  _addInteractionAreasItems(interactionAreasData, interactionAreasOptions = {}, previousInteractionAreasData) {
+  _addInteractionAreasItems(interactionAreasData, interactionAreasOptions = {}, previousInteractionAreasData, durationTime) {
     const configs = { playerOptions: this.playerOptions, videojsOptions: this._videojsOptions };
 
     if (previousInteractionAreasData) {
-      updateInteractionAreasItem(this.videojs, configs, interactionAreasData, previousInteractionAreasData, ({ event, item, index }) => {
+      updateInteractionAreasItem(this.videojs, configs, interactionAreasData, previousInteractionAreasData, durationTime, ({ event, item, index }) => {
         this._onInteractionAreasClick(interactionAreasOptions, { event, item, index });
       });
     } else {
       const interactionAreasItems = interactionAreasData.map((item, index) => {
-        return getInteractionAreaItem(configs, item, index, (event) => {
+        return getInteractionAreaItem(configs, item, index, durationTime, (event) => {
           this._onInteractionAreasClick(interactionAreasOptions, { event, item, index });
         });
       });
@@ -684,9 +684,10 @@ class VideoPlayer extends Utils.mixin(Eventable) {
       const activeCue = track.activeCues && track.activeCues[0];
 
       if (activeCue) {
+        const durationTime = Math.floor((activeCue.endTime - activeCue.startTime) * 1000);
         const tracksData = JSON.parse(activeCue.text);
 
-        this._addInteractionAreasItems(tracksData, interactionAreasConfig, previousTracksData);
+        this._addInteractionAreasItems(tracksData, interactionAreasConfig, previousTracksData, durationTime);
         !previousTracksData && this._setInteractionAreasContainerSize();
         previousTracksData = tracksData;
       } else {

--- a/src/video-player.js
+++ b/src/video-player.js
@@ -32,6 +32,7 @@ import {
 import {
   CLOSE_INTERACTION_AREA_LAYOUT_DELAY,
   INTERACTION_AREAS_CONTAINER_CLASS_NAME,
+  DEFAULT_INTERACTION_ARE_TRANSITION,
   TEMPLATE_INTERACTION_AREAS_VTT
 } from './components/interaction-area/interaction-area.const';
 import { throttle } from './utils/time';
@@ -684,7 +685,8 @@ class VideoPlayer extends Utils.mixin(Eventable) {
       const activeCue = track.activeCues && track.activeCues[0];
 
       if (activeCue) {
-        const durationTime = Math.floor((activeCue.endTime - activeCue.startTime) * 1000);
+        const durationTime = Math.max(Math.floor((activeCue.endTime - activeCue.startTime) * 1000), DEFAULT_INTERACTION_ARE_TRANSITION);
+
         const tracksData = JSON.parse(activeCue.text);
 
         this._addInteractionAreasItems(tracksData, interactionAreasConfig, previousTracksData, durationTime);

--- a/src/video-player.js
+++ b/src/video-player.js
@@ -656,7 +656,7 @@ class VideoPlayer extends Utils.mixin(Eventable) {
     });
   }
 
-  _addInteractionAreasItems(interactionAreasData, interactionAreasOptions = {}, previousInteractionAreasData, durationTime) {
+  _addInteractionAreasItems(interactionAreasData, interactionAreasOptions = {}, previousInteractionAreasData, durationTime = 0) {
     const configs = { playerOptions: this.playerOptions, videojsOptions: this._videojsOptions };
 
     if (previousInteractionAreasData) {


### PR DESCRIPTION
The developing part for [this task](https://cloudinary.atlassian.net/browse/APPS-10130) was small but it was involved some research with Eran. 
To find the best minimum duration translation time, it's not hard coded in the client, calc by endTime - startTime .

Eran sent me different vtt files (different fps time) to look how is it like on the client.  

The transition duration has been added dynamically 

There is a limitation from the video.js ,  the tracking event is every 250ms

![Screen Shot 2021-08-01 at 16 32 50](https://user-images.githubusercontent.com/76470570/127772842-aa280c18-ccce-4933-93ef-37c2f35e674e.png)


