### PR TITLE
change webpack build for ie11 support

### DIFF
--- a/webpack/es5.config.js
+++ b/webpack/es5.config.js
@@ -38,7 +38,7 @@ function optimization(mode) {
       new OptimizeCssAssetsPlugin({}),
       new TerserPlugin({
         terserOptions: {
-          ecma: 6,
+          ecma: 5,
           compress: {
             drop_debugger: true,
             pure_funcs: [


### PR DESCRIPTION
e6 {e} ->  es5 {e:e} to support ie11

before

![Screen Shot 2021-10-20 at 11 55 53](https://user-images.githubusercontent.com/76470570/138062068-03eb7eeb-b8ba-4af4-8fd7-40d76ed98827.png)
 after

![Screen Shot 2021-10-20 at 11 53 23](https://user-images.githubusercontent.com/76470570/138062095-bd776435-cc4a-4fdd-8fb6-97e27b733c8f.png)


