### PR TITLE
POP-1125-playlist-next

### DIFF
--- a/src/components/playlist/components/playlist-next-button.js
+++ b/src/components/playlist/components/playlist-next-button.js
@@ -8,6 +8,7 @@ class PlaylistNextButton extends PlaylistButton {
   }
 
   handleClick(event) {
+    event.stopPropagation();
     super.handleClick(event);
     this.player().cloudinary.playlist().playNext();
   }

--- a/src/components/playlist/components/upcoming-video-overlay.js
+++ b/src/components/playlist/components/upcoming-video-overlay.js
@@ -96,7 +96,7 @@ class UpcomingVideoOverlayContent extends Component {
   createEl() {
     // Content wraps image and bar
     return super.createEl('div', {
-      className: 'aspect-ratio-content'
+      className: 'upcoming-video-overlay aspect-ratio-content'
     });
   }
 }

--- a/src/components/playlist/components/upcoming-video-overlay.scss
+++ b/src/components/playlist/components/upcoming-video-overlay.scss
@@ -17,8 +17,9 @@ $_upcoming-video-transition: visibility 0.4s, opacity 0.4s;
   max-width: $upcoming-video-max-width;
   border: 1px solid #E8E8E9;
 
-  .aspect-ratio-content {
+  .upcoming-video-overlay {
     background-size: cover;
+    cursor: pointer;
 
     .vjs-upcoming-video-bar {
       display: flex;


### PR DESCRIPTION
This PR prevents a situation where the button click propagate to the clickable wrapper element and that caused the click handler to be called twice
Fixes https://cloudinary.atlassian.net/browse/POP-1125