### PR TITLE
fix: cld analytics events

### DIFF
--- a/docs/cloudinary-analytics-multiple-videos.html
+++ b/docs/cloudinary-analytics-multiple-videos.html
@@ -24,12 +24,19 @@
   <script type="text/javascript" src="./scripts.js"></script>
   <script type="text/javascript">
     window.addEventListener('load', function(){
-      const cld = cloudinary.Cloudinary.new({ cloud_name: 'demo', secure: true});
-      const player = cld.videoPlayer('player', { cloudinaryAnalytics: true });
+      const player = cloudinary.videoPlayer('player', { 
+         cloud_name: 'demo',
+         secure: true,
+         cloudinaryAnalytics: true 
+      });
 
       player.source('https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_2MB.mp4');
 
-      const  adpPlayer = cld.videoPlayer('adpPlayer', { cloudinaryAnalytics: true });
+      const adpPlayer = cloudinary.videoPlayer('adpPlayer', { 
+         cloud_name: 'demo',
+         secure: true,
+         cloudinaryAnalytics: true 
+      });
       adpPlayer.source('https://res.cloudinary.com/demo/video/upload/sp_hd/sea_turtle.mpd');
     }, false);
   </script>
@@ -82,13 +89,20 @@
         &lt;script type="text/javascript"&gt;
 
           // Initialize player
-          const cld = cloudinary.Cloudinary.new({ cloud_name: 'demo', secure: true});
-          const player = cld.videoPlayer('player', { cloudinaryAnalytics: true });
-
-          player.source('https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_2MB.mp4');
-
-          const  adpPlayer = cld.videoPlayer('adpPlayer', { cloudinaryAnalytics: true });
-          adpPlayer.source('https://res.cloudinary.com/demo/video/upload/sp_hd/sea_turtle.mpd');
+          const player = cloudinary.videoPlayer('player', { 
+            cloud_name: 'demo',
+            secure: true,
+            cloudinaryAnalytics: true 
+         });
+   
+         player.source('https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_2MB.mp4');
+   
+         const adpPlayer = cloudinary.videoPlayer('adpPlayer', { 
+            cloud_name: 'demo',
+            secure: true,
+            cloudinaryAnalytics: true 
+         });
+         adpPlayer.source('https://res.cloudinary.com/demo/video/upload/sp_hd/sea_turtle.mpd');
 
         &lt;/script&gt;
       </code>

--- a/docs/cloudinary-analytics-multiple-videos.html
+++ b/docs/cloudinary-analytics-multiple-videos.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cloudinary Video Player</title>
+  <link href="https://res.cloudinary.com/cloudinary-marketing/image/upload/f_auto,q_auto/c_scale,w_32/v1597183771/creative_staging/cloudinary_internal/Website/Brand%20Updates/Favicon/cloudinary_web_favicon_192x192.png" rel="icon" type="image/png">
+
+  <!-- Bootstrap -->
+  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+
+  <!-- highlight.js -->
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/solarized-light.min.css">
+  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
+
+  <!--
+    We're loading scripts & style dynamically for development/testing.
+    Real-world usage would look like this:
+
+    <link rel="stylesheet" href="https://unpkg.com/cloudinary-video-player/dist/cld-video-player.min.css">
+    <script src="https://unpkg.com/cloudinary-video-player/dist/cld-video-player.min.js"></script>
+  -->
+
+  <script type="text/javascript" src="./scripts.js"></script>
+  <script type="text/javascript">
+    window.addEventListener('load', function(){
+      const cld = cloudinary.Cloudinary.new({ cloud_name: 'demo', secure: true});
+      const player = cld.videoPlayer('player', { cloudinaryAnalytics: true });
+
+      player.source('https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_2MB.mp4');
+
+      const  adpPlayer = cld.videoPlayer('adpPlayer', { cloudinaryAnalytics: true });
+      adpPlayer.source('https://res.cloudinary.com/demo/video/upload/sp_hd/sea_turtle.mpd');
+    }, false);
+  </script>
+
+</head>
+<body>
+  <div class="container p-4 col-12 col-md-9 col-xl-6">
+
+    <nav class="nav mb-2">
+        <a href="./index.html">&#60;&#60; Back to examples index</a>
+    </nav>
+    <h1>Cloudinary Video Player</h1>
+    <h3 class="mb-4">Cloudinary analytics</h3>
+
+    <video
+            id="player"
+            playsinline
+            controls
+            muted
+            class="cld-video-player"
+            width="500"
+    ></video>
+
+    <video
+            id="adpPlayer"
+            playsinline
+            controls
+            muted
+            loop
+            class="cld-video-player"
+            width="500"
+    ></video>
+
+    <h3 class="mt-4">Example Code:</h3>
+
+    <pre>
+      <code class="language-html">
+
+        &lt;video
+          id="player"
+          controls
+          muted
+          class="cld-video-player"
+          width="500"&gt;
+        &lt;/video&gt;
+
+      </code>
+      <code class="language-javascript">
+        &lt;!-- Actual code --&gt;
+        &lt;script type="text/javascript"&gt;
+
+          // Initialize player
+          const cld = cloudinary.Cloudinary.new({ cloud_name: 'demo', secure: true});
+          const player = cld.videoPlayer('player', { cloudinaryAnalytics: true });
+
+          player.source('https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_2MB.mp4');
+
+          const  adpPlayer = cld.videoPlayer('adpPlayer', { cloudinaryAnalytics: true });
+          adpPlayer.source('https://res.cloudinary.com/demo/video/upload/sp_hd/sea_turtle.mpd');
+
+        &lt;/script&gt;
+      </code>
+    </pre>
+  </div>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,6 +55,7 @@
       <li><a href="./audio.html">Audio Player</a></li>
       <li><a href="./analytics.html">Analytics</a></li>
       <li><a href="./cloudinary-analytics.html">Cloudinary Analytics</a></li>
+      <li><a href="./cloudinary-analytics-multiple-videos.html">Cloudinary Analytics multiple videos</a></li>
       <li><a href="./components.html">Components</a></li>
       <li><a href="./recommendations.html">Recommendations</a></li>
       <li><a href="./fluid.html">Fluid Layouts</a></li>

--- a/src/components/cld-analytics/cld-analytics.js
+++ b/src/components/cld-analytics/cld-analytics.js
@@ -19,15 +19,15 @@ const getUniqueUserId = () => {
 
 // prepare events list for aggregation, for example
 // if video is being played and user wants to leave the page - add "pause" event to correctly calculate played time
-const prepareEvents = (collectedEvents, videoCurrentTime) => {
+const prepareEvents = (collectedEvents) => {
   const events = [...collectedEvents];
-  const lastPlayItemIndex = events.findIndex((event) => event.type === VIDEO_EVENT.PLAY);
-  const lastPauseItemIndex = events.findIndex((event) => event.type === VIDEO_EVENT.PAUSE);
+  const lastPlayItemIndex = events.findLastIndex((event) => event.type === VIDEO_EVENT.PLAY);
+  const lastPauseItemIndex = events.findLastIndex((event) => event.type === VIDEO_EVENT.PAUSE);
 
   if (lastPlayItemIndex > lastPauseItemIndex) {
     events.push({
       type: VIDEO_EVENT.PAUSE,
-      time: videoCurrentTime
+      time: Date.now()
     });
   }
 
@@ -52,7 +52,7 @@ const aggregateEvents = (eventsList) => {
 
 const getPlayedTimeSeconds = (watchedFrames) => {
   return Math.round(watchedFrames.reduce((acc, [playTime, pauseTime]) => {
-    return acc + (pauseTime - playTime);
+    return acc + ((pauseTime - playTime) / 1000);
   }, 0));
 };
 
@@ -74,17 +74,25 @@ export const trackVideoPlayer = (videoElement, metadataProps) => {
     });
   });
 
-  videoElement.addEventListener('play', (event) => {
+  videoElement.addEventListener('play', () => {
     collectedEvents.push({
       type: VIDEO_EVENT.PLAY,
-      time: event.target.currentTime
+      time: Date.now()
     });
   });
 
-  videoElement.addEventListener('pause', (event) => {
+  videoElement.addEventListener('pause', () => {
     collectedEvents.push({
       type: VIDEO_EVENT.PAUSE,
-      time: event.target.currentTime
+      time: Date.now()
+    });
+  });
+
+  videoElement.addEventListener('emptied', () => {
+    // simulate "pause" event when source is changed
+    collectedEvents.push({
+      type: VIDEO_EVENT.PAUSE,
+      time: Date.now()
     });
   });
 };


### PR DESCRIPTION
Change mechanism of collecting events to base on `Date.now` time instead of `currentTime` of video.
It solves many problems - mostly while seeking video, looping it.

Additionally added `emptied` event listener for interaction areas where source is changed during playing.