### PR TITLE
POP-8186-transformation-arrays-case

### DIFF
--- a/src/plugins/cloudinary/common.js
+++ b/src/plugins/cloudinary/common.js
@@ -58,6 +58,13 @@ const isTransformationInstance = (transformation) => transformation.constructor.
 const mergeTransformations = (initTransformation1, transformation2) => {
   const transformation1 = isTransformationInstance(initTransformation1) ? initTransformation1.toOptions() : initTransformation1;
 
+  if (Array.isArray(transformation2)) {
+    // Parse transformation array members (i.e. transform keys to snake_case)
+    transformation2 = transformation2.map((tr) => {
+      return new Transformation(tr).toOptions();
+    });
+  }
+
   return new Transformation(transformation1).fromOptions(transformation2).toOptions();
 };
 


### PR DESCRIPTION
Jira: https://cloudinary.atlassian.net/browse/ME-4322

The Transformation class is transforming keys inside transformation objects, but not in a transformation array
See https://codesandbox.io/s/js-sdk-transformation-legacyurl-b64xur?file=/src/index.js

This PR makes sure arrays are parsed separately before being sent