### PR TITLE
fix: set aria hidden for some empty elements

### DIFF
--- a/src/components/recommendations-overlay/recommendations-overlay-primary-item.js
+++ b/src/components/recommendations-overlay/recommendations-overlay-primary-item.js
@@ -55,12 +55,15 @@ class RecommendationsOverlayPrimaryItem extends RecommendationsOverlayItem {
     });
 
     this.title = dom.createEl('h2');
+    this.title.setAttribute('aria-hidden', 'true');
     this.title.innerHTML = '';
 
     this.subtitle = dom.createEl('h3');
+    this.subtitle.setAttribute('aria-hidden', 'true');
     this.subtitle.innerHTML = '';
 
     this.description = dom.createEl('p');
+    this.description.setAttribute('aria-hidden', 'true');
     this.description.innerHTML = '';
 
     this.content = dom.createEl('div', {


### PR DESCRIPTION
Set `aria-hidden=true` for empty headers & p elements.