### PR TITLE
ME-6552-lazy-ads - lazy load 'videojs-contrib-ads'

### DIFF
--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,5 +1,4 @@
 // #if (!process.env.WEBPACK_BUILD_LIGHT)
-import 'videojs-contrib-ads';
 import dashPlugin from './dash';
 import imaPlugin from './ima';
 import interactive from './interactive-plugin';


### PR DESCRIPTION
This PR adds `videojs-contrib-ads` to the lazy loaded module, instead of bundling it to the main one