### PR TITLE
ME-7161-poster-black-bars

### DIFF
--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -86,6 +86,9 @@ $icon-font-path: '../fonts' !default;
       // Work-around for poster having slightly wrong proportions in fluid players.
       background: #000;
       background-size: cover;
+      img {
+        object-fit: cover;
+      }
     }
   }
 


### PR DESCRIPTION
previous VP version, no problem - https://codesandbox.io/s/dank-tree-9lxj3s?file=/index.html
latest VP version, poster does not cover - https://codesandbox.io/s/clever-blackwell-x79g7p?file=/index.html

This happened because to poster implementation changed from background-image to an actual `<img>` tag
This PR fixes it so that the new poster structure will behave the same