### PR TITLE
ME-14916-picture-in-picture-fix

### DIFF
--- a/src/video-player.js
+++ b/src/video-player.js
@@ -338,7 +338,7 @@ class VideoPlayer extends Utils.mixin(Eventable) {
 
   // #if (!process.env.WEBPACK_BUILD_LIGHT)
   _initQualitySelector() {
-    if (this._videojsOptions.controlBar && this.playerOptions.qualitySelector !== false) {
+    if (this.videojs.controlBar && this.playerOptions.qualitySelector !== false) {
       this.videojs.httpSourceSelector({ default: 'auto' });
 
       this.videojs.on(PLAYER_EVENT.LOADED_METADATA, () => {


### PR DESCRIPTION
There was a wrong check for a `controlBar`, which caused the selector to not show, now that we don't pass the `controlBar` config object by default.
This PR fixes that