### PR TITLE
ME-15490-playlist-by-tag

### DIFF
--- a/src/plugins/playlist/playlist.js
+++ b/src/plugins/playlist/playlist.js
@@ -77,7 +77,7 @@ const playlist = (player, options = {}) => {
   player.cloudinary.sourcesByTag = async (tag, options = {}) => {
     const url = getCloudinaryUrl(
       tag,
-      Object.assign(player.cloudinary.cloudinaryConfig(), LIST_BY_TAG_PARAMS)
+      Object.assign({}, player.cloudinary.cloudinaryConfig(), LIST_BY_TAG_PARAMS)
     );
 
     const result = await fetch(url);

--- a/src/video-player.js
+++ b/src/video-player.js
@@ -576,7 +576,7 @@ class VideoPlayer extends Utils.mixin(Eventable) {
   playlist(sources, options = {}) {
     options = Utils.assign({}, options, { playlistWidget: this.playerOptions.playlistWidget });
 
-    this.videojs.on(PLAYER_EVENT.READY, async () => {
+    this.videojs.one(PLAYER_EVENT.READY, async () => {
       const playlistPlugin = await this.videojs.playlist(options);
       playlistPlugin(sources, options);
     });
@@ -588,7 +588,7 @@ class VideoPlayer extends Utils.mixin(Eventable) {
     options = Utils.assign({}, options, { playlistWidget: this.playerOptions.playlistWidget });
 
     return new Promise((resolve) => {
-      this.videojs.on(PLAYER_EVENT.READY, async () => {
+      this.videojs.one(PLAYER_EVENT.READY, async () => {
         const playlistPlugin = await this.videojs.playlist(options);
         playlistPlugin(await this.sourcesByTag(tag, options), options);
         resolve(this);


### PR DESCRIPTION
This PR fixes an issue that seem to be introduced in 1.10.2 when we introduced `f_auto` as default
https://cloudinary.github.io/cloudinary-video-player/playlist-by-tag-captions.html?ver=latest&min=true