### PR TITLE
fix: mimetypes

### DIFF
--- a/src/plugins/cloudinary/models/video-source/video-source.const.js
+++ b/src/plugins/cloudinary/models/video-source/video-source.const.js
@@ -37,12 +37,32 @@ export const VIDEO_SUFFIX_REMOVAL_PATTERN = RegExp(`\\.(${COMMON_VIDEO_EXTENSION
 // eslint-disable-next-line no-control-regex
 export const URL_PATTERN = RegExp('https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\+.~#?&/=]*)');
 
-
 export const CONTAINER_MIME_TYPES = {
-  dash: ['application/dash+xml'],
-  hls: ['application/x-mpegURL'],
-  mpd: ['application/dash+xml'],
-  m3u8: ['application/x-mpegURL']
+  hls: 'application/x-mpegURL',
+  dash: 'application/dash+xml',
+
+  // See: https://docs.videojs.com/utils_mimetypes.js.html
+  opus: 'video/ogg',
+  ogv: 'video/ogg',
+  mp4: 'video/mp4',
+  mov: 'video/mp4',
+  m4v: 'video/mp4',
+  mkv: 'video/x-matroska',
+  m4a: 'audio/mp4',
+  mp3: 'audio/mpeg',
+  aac: 'audio/aac',
+  caf: 'audio/x-caf',
+  flac: 'audio/flac',
+  oga: 'audio/ogg',
+  wav: 'audio/wav',
+  m3u8: 'application/x-mpegURL',
+  mpd: 'application/dash+xml',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  png: 'image/png',
+  svg: 'image/svg+xml',
+  webp: 'image/webp'
 };
 
 export const FORMAT_MAPPINGS = {

--- a/src/plugins/cloudinary/models/video-source/video-source.const.js
+++ b/src/plugins/cloudinary/models/video-source/video-source.const.js
@@ -65,6 +65,8 @@ export const CONTAINER_MIME_TYPES = {
   webp: 'image/webp'
 };
 
+export const ADAPTIVE_SOURCETYPES = ['hls', 'dash', 'mpd', 'm3u8'];
+
 export const FORMAT_MAPPINGS = {
   hls: 'm3u8',
   dash: 'mpd'

--- a/src/plugins/cloudinary/models/video-source/video-source.js
+++ b/src/plugins/cloudinary/models/video-source/video-source.js
@@ -186,8 +186,7 @@ class VideoSource extends BaseSource {
 
   generateSources() {
     if (this.isRawUrl) {
-      const type = this.sourceTypes()[0] === 'auto' ? null : this.sourceTypes()[0];
-      return [this.generateRawSource(this.publicId(), type)];
+      return [this.generateRawSource(this.publicId())];
     }
 
     const srcs = this.sourceTypes().map(sourceType => {
@@ -243,11 +242,11 @@ class VideoSource extends BaseSource {
     return srcs;
   }
 
-  generateRawSource(url, type) {
-    const t = type || url.split('.').pop();
-    const isAdaptive = !!CONTAINER_MIME_TYPES[t];
-    if (isAdaptive) {
-      type = CONTAINER_MIME_TYPES[t][0];
+  generateRawSource(url) {
+    let type = url.split('.').pop();
+    const isAdaptive = ['mpd', 'm3u8'].indexOf(type) !== -1;
+    if (CONTAINER_MIME_TYPES[type]) {
+      type = CONTAINER_MIME_TYPES[type];
     } else {
       type = type ? `video/${type}` : null;
     }

--- a/src/plugins/cloudinary/models/video-source/video-source.js
+++ b/src/plugins/cloudinary/models/video-source/video-source.js
@@ -186,7 +186,8 @@ class VideoSource extends BaseSource {
 
   generateSources() {
     if (this.isRawUrl) {
-      return [this.generateRawSource(this.publicId())];
+      const type = this.sourceTypes()[0] === 'auto' ? null : this.sourceTypes()[0];
+      return [this.generateRawSource(this.publicId(), type)];
     }
 
     const srcs = this.sourceTypes().map(sourceType => {
@@ -242,9 +243,11 @@ class VideoSource extends BaseSource {
     return srcs;
   }
 
-  generateRawSource(url) {
-    let type = url.split('.').pop();
-    const isAdaptive = ['mpd', 'm3u8'].indexOf(type) !== -1;
+  generateRawSource(url, type) {
+    type = type || url.split('.').pop();
+
+    const isAdaptive = ['hls', 'dash', 'mpd', 'm3u8'].indexOf(type) !== -1;
+
     if (CONTAINER_MIME_TYPES[type]) {
       type = CONTAINER_MIME_TYPES[type];
     } else {

--- a/src/plugins/cloudinary/models/video-source/video-source.js
+++ b/src/plugins/cloudinary/models/video-source/video-source.js
@@ -5,6 +5,7 @@ import { castArray } from 'utils/array';
 import { SOURCE_TYPE } from 'utils/consts';
 import {
   CONTAINER_MIME_TYPES,
+  ADAPTIVE_SOURCETYPES,
   DEFAULT_POSTER_PARAMS,
   DEFAULT_VIDEO_PARAMS,
   VIDEO_SUFFIX_REMOVAL_PATTERN
@@ -193,7 +194,7 @@ class VideoSource extends BaseSource {
     const srcs = this.sourceTypes().map(sourceType => {
       const srcTransformation = this.sourceTransformation()[sourceType] || this.transformation();
       const format = normalizeFormat(sourceType);
-      const isAdaptive = ['mpd', 'm3u8'].indexOf(format) !== -1;
+      const isAdaptive = ADAPTIVE_SOURCETYPES.includes(format);
       const opts = {};
 
       if (srcTransformation) {
@@ -246,7 +247,7 @@ class VideoSource extends BaseSource {
   generateRawSource(url, type) {
     type = type || url.split('.').pop();
 
-    const isAdaptive = ['hls', 'dash', 'mpd', 'm3u8'].indexOf(type) !== -1;
+    const isAdaptive = ADAPTIVE_SOURCETYPES.includes(type);
 
     if (CONTAINER_MIME_TYPES[type]) {
       type = CONTAINER_MIME_TYPES[type];

--- a/src/plugins/cloudinary/models/video-source/video-source.utils.js
+++ b/src/plugins/cloudinary/models/video-source/video-source.utils.js
@@ -6,16 +6,12 @@ import { some } from '../../../../utils/array';
 
 export function formatToMimeTypeAndTransformation(format) {
   const [container, codec] = format.toLowerCase().split('\/');
-  let result = CONTAINER_MIME_TYPES[container];
-  let transformation = null;
-
-  if (!result) {
-    result = [`video/${container}`, transformation];
-  }
+  const mimetype = CONTAINER_MIME_TYPES[container] || `video/${container}`;
+  let result = [mimetype];
 
   if (codec) {
-    transformation = codecToSrcTransformation(codec);
-    result = [`${result[0]}; codecs="${codecShorthandTrans(codec)}"`, transformation];
+    const transformation = codecToSrcTransformation(codec);
+    result = [`${CONTAINER_MIME_TYPES[container]}; codecs="${codecShorthandTrans(codec)}"`, transformation];
   }
 
   return result;

--- a/src/plugins/cloudinary/models/video-source/video-source.utils.js
+++ b/src/plugins/cloudinary/models/video-source/video-source.utils.js
@@ -11,7 +11,7 @@ export function formatToMimeTypeAndTransformation(format) {
 
   if (codec) {
     const transformation = codecToSrcTransformation(codec);
-    result = [`${CONTAINER_MIME_TYPES[container]}; codecs="${codecShorthandTrans(codec)}"`, transformation];
+    result = [`${mimetype}; codecs="${codecShorthandTrans(codec)}"`, transformation];
   }
 
   return result;

--- a/src/utils/cloudinary.js
+++ b/src/utils/cloudinary.js
@@ -34,7 +34,7 @@ const setError = (that, res) => {
 };
 
 const setVideoSrc = (that, srcs) => {
-  console.log('Trying urls: ' + JSON.stringify(srcs));
+  console.log('Trying sources: ', srcs);
   srcs.forEach(s => {
     s.try = true;
   });

--- a/test/unit/videoSource.test.js
+++ b/test/unit/videoSource.test.js
@@ -158,7 +158,7 @@ describe('Raw url tests', () => {
     let source = new VideoSource(url, sourceDef);
     let srcs = source.generateSources();
     expect(srcs[0].src).toEqual(url);
-    expect(srcs[0].type).toEqual(null);
+    expect(srcs[0].type).toEqual('video/mp4');
     expect(srcs[0].isAdaptive).toEqual(false);
   });
   it('Test raw url with transformations', () => {
@@ -169,7 +169,7 @@ describe('Raw url tests', () => {
     let source = new VideoSource(url, sourceDef);
     let srcs = source.generateSources();
     expect(srcs[0].src).toEqual(url);
-    expect(srcs[0].type).toEqual(null);
+    expect(srcs[0].type).toEqual('video/mp4');
     expect(srcs[0].isAdaptive).toEqual(false);
   });
   it('Test raw url without extension', () => {


### PR DESCRIPTION
This PR fixes our mimetypes testing logic.
Until now we were simply using the file extension for non ABR, which was ok for some types but bad for others.
This is now aligned with [videojs mimetypes](https://docs.videojs.com/utils_mimetypes.js.html)