### PR TITLE
perf!: default export to be base videoPlayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Cloudinary Video Player",
   "author": "Cloudinary",
   "license": "MIT",
+  "module": "./lib/videoPlayer.js",
   "main": "./dist/cld-video-player.min.js",
-  "module": "./lib/cld-video-player.js",
   "style": "./dist/cld-video-player.min.css",
   "types": "./types/cld-video-player.d.ts",
   "files": [


### PR DESCRIPTION
BREAKING CHANGE: the default ES import is now only the player core plugins need to be explicitly imported