### PR TITLE
build: add default profiles json files to build output in es version

### DIFF
--- a/webpack/es6.config.js
+++ b/webpack/es6.config.js
@@ -31,7 +31,7 @@ module.exports = merge(webpackCommon, {
     new CopyWebpackPlugin({
       patterns: [{
         from: path.resolve(__dirname, '../src/config/profiles'),
-        to: `${outputPath}/default-player-profiles`
+        to: `${outputPath}/profiles`
       }]
     })
   ],

--- a/webpack/es6.config.js
+++ b/webpack/es6.config.js
@@ -1,8 +1,11 @@
 const { merge } = require('webpack-merge');
 const webpackCommon = require('./common.config');
 const path = require('path');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 delete webpackCommon.output; // overwrite
+
+const outputPath = path.resolve(__dirname, '../lib');
 
 module.exports = merge(webpackCommon, {
   mode: 'production',
@@ -16,13 +19,22 @@ module.exports = merge(webpackCommon, {
 
   output: {
     filename: '[name].js',
-    path: path.resolve(__dirname, '../lib'),
+    path: outputPath,
     chunkFilename: '[name].js',
     publicPath: '',
     library: {
       type: 'module'
     }
   },
+
+  plugins: [
+    new CopyWebpackPlugin({
+      patterns: [{
+        from: path.resolve(__dirname, '../src/config/profiles'),
+        to: `${outputPath}/default-player-profiles`
+      }]
+    })
+  ],
 
   experiments: {
     outputModule: true


### PR DESCRIPTION
Export default profiles as raw json files so they can be imported directly in BFF.

<img width="431" alt="image" src="https://github.com/cloudinary/cloudinary-video-player/assets/70572646/94729875-2923-4e99-9f6b-e52401e4229d">
