### PR TITLE
fix: use videojs events & re-trigger to analytics package with custom…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@cloudinary/url-gen": "^1.19.0",
-        "cloudinary-video-analytics": "1.5.0",
+        "cloudinary-video-analytics": "1.6.0",
         "lodash": "^4.17.21",
         "uuid": "^9.0.1",
         "video.js": "^8.11.8",
@@ -6278,9 +6278,9 @@
       }
     },
     "node_modules/cloudinary-video-analytics": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/cloudinary-video-analytics/-/cloudinary-video-analytics-1.5.0.tgz",
-      "integrity": "sha512-CxQonA3lOeZrtapnbg7Gs7IBDZrujgiikcbXzBMTVGRNWIzovCtYUnddTMDCqTlz7UwhRkC/gMlYzMDwnZeRpQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cloudinary-video-analytics/-/cloudinary-video-analytics-1.6.0.tgz",
+      "integrity": "sha512-SdUKK6J35RiZEyjpTzXxH4nLDAJtwj3NYa35LCLtad6EtwYrbV92myyMm96B85ogDdhjHWM6RAxJnHPkIUOPRA==",
       "dependencies": {
         "is-mobile": "^4.0.0",
         "uuid": "9.0.0"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "@cloudinary/url-gen": "^1.19.0",
-    "cloudinary-video-analytics": "1.5.0",
+    "cloudinary-video-analytics": "1.6.0",
     "lodash": "^4.17.21",
     "uuid": "^9.0.1",
     "video.js": "^8.11.8",

--- a/src/plugins/cloudinary-analytics/index.js
+++ b/src/plugins/cloudinary-analytics/index.js
@@ -1,5 +1,5 @@
 import videojs from 'video.js';
-import { connectCloudinaryAnalytics } from '../../../../cloudinary-video-analytics';
+import { connectCloudinaryAnalytics } from 'cloudinary-video-analytics';
 import { PLAYER_EVENT } from '../../utils/consts';
 
 class CloudinaryAnalytics {

--- a/src/plugins/cloudinary-analytics/index.js
+++ b/src/plugins/cloudinary-analytics/index.js
@@ -1,10 +1,14 @@
-import { connectCloudinaryAnalytics } from 'cloudinary-video-analytics';
+import videojs from 'video.js';
+import { connectCloudinaryAnalytics } from '../../../../cloudinary-video-analytics';
 import { PLAYER_EVENT } from '../../utils/consts';
 
 class CloudinaryAnalytics {
   constructor(player) {
     this.player = player;
-    this.cloudinaryAnalytics = connectCloudinaryAnalytics(this.player.videoElement);
+    this.shouldUseCustomEvents = videojs.browser.IS_IOS;
+    this.cloudinaryAnalytics = connectCloudinaryAnalytics(this.player.videoElement, {
+      customEvents: this.shouldUseCustomEvents,
+    });
     this.currentVideMetadata = {
       cloudName: null,
       publicId: null
@@ -29,7 +33,31 @@ class CloudinaryAnalytics {
     }
   };
 
+  dispatchCustomEventOnVideoPlayer = (name, detail = {}) => {
+    const ev = new CustomEvent(`cld-custom-${name}`, {
+      detail,
+    });
+    this.player.videoElement.dispatchEvent(ev);
+  };
+
+  connectCustomEvents = () => {
+    this.player.on(PLAYER_EVENT.PLAY, () => this.dispatchCustomEventOnVideoPlayer('play'));
+    this.player.on(PLAYER_EVENT.PAUSE, () => this.dispatchCustomEventOnVideoPlayer('pause'));
+    this.player.on(PLAYER_EVENT.EMPTIED, () => this.dispatchCustomEventOnVideoPlayer('emptied'));
+    this.player.on(PLAYER_EVENT.LOADED_METADATA, () => {
+      const videoDuration = this.player.videoElement.duration || null;
+      this.dispatchCustomEventOnVideoPlayer('loadedmetadata', {
+        videoDuration,
+      });
+    });
+  };
+
   init() {
+    // only for iOS there is problem with reporting events because videojs re-triggers events and stops native ones
+    if (this.shouldUseCustomEvents) {
+      this.connectCustomEvents();
+    }
+
     this.player.on(PLAYER_EVENT.CLD_SOURCE_CHANGED, this.sourceChanged);
   }
 }

--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -10,6 +10,7 @@ export const PLAYER_EVENT = {
   PAUSE_NO_SEEK: 'pausenoseek',
   ERROR: 'error',
   TIME_UPDATE: 'timeupdate',
+  EMPTIED: 'emptied',
   RETRY_PLAYLIST: 'retryplaylist',
   CAN_PLAY_THROUGH: 'canplaythrough',
   CLD_SOURCE_CHANGED: 'cldsourcechanged',


### PR DESCRIPTION
Unfortunately video.js intercept all video events on HTML tag which causes problems only on iOS mobile browsers.
The only solution that works is to trigger our own events (custom events) from VP side.