### PR TITLE
fix: text track with no src should fall-back to transcript

### DIFF
--- a/src/utils/cloudinary.js
+++ b/src/utils/cloudinary.js
@@ -101,14 +101,14 @@ const isKeyInTransformation = (transformation, key) => {
 
 const addTextTracks = (tracks, videojs) => {
   tracks.forEach(track => {
-    if ((track.maxWords || track.wordHighlight) && videojs.pacedTranscript) {
-      videojs.pacedTranscript(track);
-    } else if (track.src) {
+    if (track.src) {
       fetch(track.src, GET_ERROR_DEFAULT_REQUEST).then(r => {
         if (r.status >= 200 && r.status <= 399) {
           videojs.addRemoteTextTrack(track, true);
         }
       });
+    } else if (videojs.pacedTranscript) {
+      videojs.pacedTranscript(track);
     }
   });
 };


### PR DESCRIPTION
This PR introduces a small change to the transcript fetching logic.
Previously we fetched transcript only if `maxWords` or `wordHighlight` were configured, but in reality you might want the transcript without any of those.
This changes the condition so that if a text-track is configured without specifying a `src` it will try fetching the transcript file