### PR TITLE
fix: programatic text-tracks in Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
       },
       {
         "path": "./dist/cld-video-player.light.min.js",
-        "maxSize": "131kb"
+        "maxSize": "135kb"
       },
       {
         "path": "./lib/cld-video-player.js",

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -29,6 +29,6 @@ export default {
   allowUsageReport: true,
   playedEventPercents: [25, 50, 75, 100],
   html5: {
-    nativeTextTracks: !videojs?.browser?.IS_SAFARI
+    nativeTextTracks: false
   }
 };

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -27,5 +27,8 @@ export default {
   analytics: false,
   cloudinaryAnalytics: true,
   allowUsageReport: true,
-  playedEventPercents: [25, 50, 75, 100]
+  playedEventPercents: [25, 50, 75, 100],
+  html5: {
+    nativeTextTracks: !videojs?.browser?.IS_SAFARI
+  }
 };

--- a/src/plugins/chapters/chapters.js
+++ b/src/plugins/chapters/chapters.js
@@ -100,10 +100,6 @@ const ChaptersPlugin = (function () {
         default: true
       });
 
-      // required for Safari to display the captions
-      // https://github.com/videojs/video.js/issues/8519
-      await new Promise(resolve => setTimeout(resolve, 100));
-
       const end = this.player.duration();
       Object.entries(this.options).forEach((entry, index, arr) => {
         const cue = new VTTCue(

--- a/src/plugins/paced-transcript/index.js
+++ b/src/plugins/paced-transcript/index.js
@@ -64,10 +64,6 @@ function pacedTranscript(config) {
       mode: options.default ? 'showing' : 'disabled'
     });
 
-    // required for Safari to display the captions
-    // https://github.com/videojs/video.js/issues/8519
-    await new Promise(resolve => setTimeout(resolve, 100));
-
     captions.forEach(caption => {
       captionsTrack.track.addCue(new VTTCue(caption.startTime, caption.endTime, caption.text));
     });

--- a/src/plugins/srt-text-tracks/srt-text-tracks.js
+++ b/src/plugins/srt-text-tracks/srt-text-tracks.js
@@ -27,10 +27,6 @@ function srtTextTracks(config, player) {
       mode: config.default ? 'showing' : 'disabled'
     });
 
-    // required for Safari to display the captions
-    // https://github.com/videojs/video.js/issues/8519
-    await new Promise(resolve => setTimeout(resolve, 100));
-
     // Add the WebVTT data to the track
     webvttCues.forEach(cue => {
       if (cue) {
@@ -47,7 +43,7 @@ function srtTextTracks(config, player) {
 // SRT parser
 const srt2webvtt = data => {
   const SRTParser = new srtParser2();
-  
+
   const cues = SRTParser.fromSrt(data);
 
   return cues.map(cue => ({


### PR DESCRIPTION
This PR disables `nativeTextTracks` in Safari.
We did everything possible to use the native text tracks, but we now realize it never worked good enough so falling back to our emulated text tracks.