### PR TITLE
fix: seek-thumbs positioning

### DIFF
--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -30,5 +30,6 @@ export default {
   playedEventPercents: [25, 50, 75, 100],
   html5: {
     nativeTextTracks: false
-  }
+  },
+  disableSeekWhileScrubbingOnMobile: true
 };

--- a/src/video-player.utils.js
+++ b/src/video-player.utils.js
@@ -128,11 +128,4 @@ export const overrideDefaultVideojsComponents = () => {
     children.splice(children.indexOf('skipForward'), 1);
     children.splice(children.indexOf('skipBackward'), 1);
   }
-
-  const SeekBar = videojs.getComponent('SeekBar');
-  if (SeekBar && !SeekBar.prototype.options_.children.includes('mouseTimeDisplay')) {
-    // videojs isn't adding th timeDisplay on mobile, we want it for the chapters display
-    SeekBar.prototype.options_.children.splice(1, 0, 'mouseTimeDisplay');
-  }
-
 };


### PR DESCRIPTION
Fixes a regression caused by [this change](https://github.com/videojs/video.js/blame/19ca3f2ebe0ec7f0374fa3bc7df1457f9f185823/src/js/control-bar/progress-control/seek-bar.js#L52) in videojs.

Now, our hacky work-around is not needed anymore, and we can simply configure the player to behave nicely on mobile.