### PR TITLE
me-17959: test if videos on Cloudinary analytics and codecs and formats pages are playing

### DIFF
--- a/test/e2e/components/videoComponent.ts
+++ b/test/e2e/components/videoComponent.ts
@@ -29,4 +29,15 @@ export class VideoComponent extends BaseComponent {
             return video.paused;
         }, this.props.selector);
     }
+
+    /**
+     * Validates whether the video is paused or playing.
+     * expectedPaused - True if the video is expected to be paused, otherwise false.
+     */
+    public async validateVideoPaused(expectedPaused: boolean): Promise<void> {
+        const isPaused = await this.isPaused();
+        if (isPaused !== expectedPaused) {
+            throw new Error(`Video paused state mismatch. Expected: ${expectedPaused}, Actual: ${isPaused}`);
+        }
+    }
 }

--- a/test/e2e/specs/cldAnalyticsPage.spec.ts
+++ b/test/e2e/specs/cldAnalyticsPage.spec.ts
@@ -12,17 +12,17 @@ vpTest(`Test if 4 videos on Cloudinary analytics page are playing as expected`, 
         await waitForPageToLoadWithTimeout(page, 5000);
     });
     await test.step('Validating that the first video is playing (in case isPause is false)', async () => {
-        expect(await pomPages.cldAnalyticsPage.cldAnalyticsVideoComponent.isPaused()).toEqual(false);
+        expect(await pomPages.cldAnalyticsPage.cldAnalyticsVideoComponent.validateVideoPaused(false));
     });
     await test.step('Validating that the second video is playing (in case isPause is false)', async () => {
-        expect(await pomPages.cldAnalyticsPage.cldAnalyticsAdpVideoComponent.isPaused()).toEqual(false);
+        expect(await pomPages.cldAnalyticsPage.cldAnalyticsAdpVideoComponent.validateVideoPaused(false));
     });
     await test.step('Scroll until the third video element is visible', async () => {
         await pomPages.cldAnalyticsPage.cldAnalyticsCustomDataObjectVideoComponent.locator.scrollIntoViewIfNeeded();
     });
     await test.step('Validating that the third video is playing (in case isPause is false)', async () => {
         await expect(async () => {
-            expect(await pomPages.cldAnalyticsPage.cldAnalyticsCustomDataObjectVideoComponent.isPaused()).toEqual(false);
+            expect(await pomPages.cldAnalyticsPage.cldAnalyticsCustomDataObjectVideoComponent.validateVideoPaused(false));
         }).toPass({ intervals: [500], timeout: 3000 });
     });
     await test.step('Scroll until the fourth video element is visible', async () => {
@@ -30,7 +30,7 @@ vpTest(`Test if 4 videos on Cloudinary analytics page are playing as expected`, 
     });
     await test.step('Validating that the fourth video is playing (in case isPause is false)', async () => {
         await expect(async () => {
-            expect(await pomPages.cldAnalyticsPage.cldAnalyticsCustomDataFunctionVideoComponent.isPaused()).toEqual(false);
+            expect(await pomPages.cldAnalyticsPage.cldAnalyticsCustomDataFunctionVideoComponent.validateVideoPaused(false));
         }).toPass({ intervals: [500], timeout: 3000 });
     });
 });

--- a/test/e2e/specs/cldAnalyticsPage.spec.ts
+++ b/test/e2e/specs/cldAnalyticsPage.spec.ts
@@ -1,0 +1,36 @@
+import { vpTest } from '../fixtures/vpTest';
+import { expect, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../src/helpers/waitForPageToLoadWithTimeout';
+import { getLinkByName } from '../testData/pageLinksData';
+import { ExampleLinkName } from '../testData/ExampleLinkNames';
+
+const link = getLinkByName(ExampleLinkName.CloudinaryAnalytics);
+
+vpTest(`Test if 4 videos on Cloudinary analytics page are playing as expected`, async ({ page, pomPages }) => {
+    await test.step('Navigate to Cloudinary analytics page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that the first video is playing (in case isPause is false)', async () => {
+        expect(await pomPages.cldAnalyticsPage.cldAnalyticsVideoComponent.isPaused()).toEqual(false);
+    });
+    await test.step('Validating that the second video is playing (in case isPause is false)', async () => {
+        expect(await pomPages.cldAnalyticsPage.cldAnalyticsAdpVideoComponent.isPaused()).toEqual(false);
+    });
+    await test.step('Scroll until the third video element is visible', async () => {
+        await pomPages.cldAnalyticsPage.cldAnalyticsCustomDataObjectVideoComponent.locator.scrollIntoViewIfNeeded();
+    });
+    await test.step('Validating that the third video is playing (in case isPause is false)', async () => {
+        await expect(async () => {
+            expect(await pomPages.cldAnalyticsPage.cldAnalyticsCustomDataObjectVideoComponent.isPaused()).toEqual(false);
+        }).toPass({ intervals: [500], timeout: 3000 });
+    });
+    await test.step('Scroll until the fourth video element is visible', async () => {
+        await pomPages.cldAnalyticsPage.cldAnalyticsCustomDataFunctionVideoComponent.locator.scrollIntoViewIfNeeded();
+    });
+    await test.step('Validating that the fourth video is playing (in case isPause is false)', async () => {
+        await expect(async () => {
+            expect(await pomPages.cldAnalyticsPage.cldAnalyticsCustomDataFunctionVideoComponent.isPaused()).toEqual(false);
+        }).toPass({ intervals: [500], timeout: 3000 });
+    });
+});

--- a/test/e2e/specs/codecsAndFormats.spec.ts
+++ b/test/e2e/specs/codecsAndFormats.spec.ts
@@ -1,0 +1,28 @@
+import { vpTest } from '../fixtures/vpTest';
+import { expect, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../src/helpers/waitForPageToLoadWithTimeout';
+import { getLinkByName } from '../testData/pageLinksData';
+import { ExampleLinkName } from '../testData/ExampleLinkNames';
+
+const link = getLinkByName(ExampleLinkName.CodecsAndFormats);
+
+vpTest(`Test if 3 videos on codecs and formats page are playing as expected`, async ({ page, pomPages }) => {
+    await test.step('Navigate to codecs and formats page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that the first video is playing (in case isPause is false)', async () => {
+        expect(await pomPages.codecsAndFormatsPage.codecsAndFormatsFAutoVideoComponent.validateVideoPaused(false));
+    });
+    await test.step('Validating that the second video is playing (in case isPause is false)', async () => {
+        expect(await pomPages.codecsAndFormatsPage.codecsAndFormatsAv1VideoComponent.validateVideoPaused(false));
+    });
+    await test.step('Scroll until the third video element is visible', async () => {
+        await pomPages.codecsAndFormatsPage.codecsAndFormatsVp9VideoComponent.locator.scrollIntoViewIfNeeded();
+    });
+    await test.step('Validating that the third video is playing (in case isPause is false)', async () => {
+        await expect(async () => {
+            expect(await pomPages.codecsAndFormatsPage.codecsAndFormatsVp9VideoComponent.validateVideoPaused(false));
+        }).toPass({ intervals: [500], timeout: 3000 });
+    });
+});

--- a/test/e2e/src/pom/PageManager.ts
+++ b/test/e2e/src/pom/PageManager.ts
@@ -7,6 +7,7 @@ import { ApiAndEventsPage } from './apiAndEventsPage';
 import { AudioPlayerPage } from './audioPlayerPage';
 import { AutoplayOnScrollPage } from './autoplayOnScrollPage';
 import { ChaptersPage } from './chaptersPage';
+import { CldAnalyticsPage } from './cldAnalyticsPage';
 
 /**
  * Page manager,
@@ -79,6 +80,13 @@ export class PageManager {
      */
     public get chaptersPage(): ChaptersPage {
         return this.getPage(ChaptersPage);
+    }
+
+    /**
+     * Returns Cloudinary analytics page object
+     */
+    public get cldAnalyticsPage(): CldAnalyticsPage {
+        return this.getPage(CldAnalyticsPage);
     }
 }
 export default PageManager;

--- a/test/e2e/src/pom/PageManager.ts
+++ b/test/e2e/src/pom/PageManager.ts
@@ -8,6 +8,7 @@ import { AudioPlayerPage } from './audioPlayerPage';
 import { AutoplayOnScrollPage } from './autoplayOnScrollPage';
 import { ChaptersPage } from './chaptersPage';
 import { CldAnalyticsPage } from './cldAnalyticsPage';
+import { CodecsAndFormats } from './codecsAndFormats';
 
 /**
  * Page manager,
@@ -87,6 +88,13 @@ export class PageManager {
      */
     public get cldAnalyticsPage(): CldAnalyticsPage {
         return this.getPage(CldAnalyticsPage);
+    }
+
+    /**
+     * Returns codecs and formats page object
+     */
+    public get codecsAndFormatsPage(): CodecsAndFormats {
+        return this.getPage(CodecsAndFormats);
     }
 }
 export default PageManager;

--- a/test/e2e/src/pom/cldAnalyticsPage.ts
+++ b/test/e2e/src/pom/cldAnalyticsPage.ts
@@ -1,0 +1,25 @@
+import { Page } from '@playwright/test';
+import { VideoComponent } from '../../components/videoComponent';
+import { BasePage } from './BasePage';
+const CLD_ANALYTICS_PAGE_VIDEO_SELECTOR = '//*[@id="player_html5_api"]';
+const CLD_ANALYTICS_PAGE_ADP_VIDEO_SELECTOR = '//*[@id="adpPlayer_html5_api"]';
+const CLD_ANALYTICS_PAGE_CUSTOM_DATA_OBJECT_VIDEO_SELECTOR = '//*[@id="player-custom-data-plain-object_html5_api"]';
+const CLD_ANALYTICS_PAGE_CUSTOM_DATA_FUNCTION_VIDEO_SELECTOR = '//*[@id="player-custom-data-function_html5_api"]';
+
+/**
+ * Video player examples chapters page object
+ */
+export class CldAnalyticsPage extends BasePage {
+    public cldAnalyticsVideoComponent: VideoComponent;
+    public cldAnalyticsAdpVideoComponent: VideoComponent;
+    public cldAnalyticsCustomDataObjectVideoComponent: VideoComponent;
+    public cldAnalyticsCustomDataFunctionVideoComponent: VideoComponent;
+
+    constructor(page: Page) {
+        super(page);
+        this.cldAnalyticsVideoComponent = new VideoComponent(page, CLD_ANALYTICS_PAGE_VIDEO_SELECTOR);
+        this.cldAnalyticsAdpVideoComponent = new VideoComponent(page, CLD_ANALYTICS_PAGE_ADP_VIDEO_SELECTOR);
+        this.cldAnalyticsCustomDataObjectVideoComponent = new VideoComponent(page, CLD_ANALYTICS_PAGE_CUSTOM_DATA_OBJECT_VIDEO_SELECTOR);
+        this.cldAnalyticsCustomDataFunctionVideoComponent = new VideoComponent(page, CLD_ANALYTICS_PAGE_CUSTOM_DATA_FUNCTION_VIDEO_SELECTOR);
+    }
+}

--- a/test/e2e/src/pom/codecsAndFormats.ts
+++ b/test/e2e/src/pom/codecsAndFormats.ts
@@ -1,0 +1,22 @@
+import { Page } from '@playwright/test';
+import { VideoComponent } from '../../components/videoComponent';
+import { BasePage } from './BasePage';
+const CODECS_AND_FORMAT_PAGE_F_AUTO_VIDEO_SELECTOR = '//*[@id="player_html5_api"]';
+const CODECS_AND_FORMAT_PAGE_AV1_VIDEO_SELECTOR = '//*[@id="player-av1_html5_api"]';
+const CODECS_AND_FORMAT_PAGE_VP9_VIDEO_SELECTOR = '//*[@id="player-vp9_html5_api"]';
+
+/**
+ * Video player examples chapters page object
+ */
+export class CodecsAndFormats extends BasePage {
+    public codecsAndFormatsFAutoVideoComponent: VideoComponent;
+    public codecsAndFormatsAv1VideoComponent: VideoComponent;
+    public codecsAndFormatsVp9VideoComponent: VideoComponent;
+
+    constructor(page: Page) {
+        super(page);
+        this.codecsAndFormatsFAutoVideoComponent = new VideoComponent(page, CODECS_AND_FORMAT_PAGE_F_AUTO_VIDEO_SELECTOR);
+        this.codecsAndFormatsAv1VideoComponent = new VideoComponent(page, CODECS_AND_FORMAT_PAGE_AV1_VIDEO_SELECTOR);
+        this.codecsAndFormatsVp9VideoComponent = new VideoComponent(page, CODECS_AND_FORMAT_PAGE_VP9_VIDEO_SELECTOR);
+    }
+}


### PR DESCRIPTION
Relevant tasks - https://cloudinary.atlassian.net/browse/ME-17959 and https://cloudinary.atlassian.net/browse/ME-17960
The PR includes 2 tests:
1. Navigating to Cloudinary analytics page (cloudinary-analytics.html) and make sure that 4 videos element are playing (checking that the video is not paused).
2. Navigating to codecs and formats page (codec-formats.html) and make sure that 3 videos element are playing (checking that the video is not paused).