### PR TITLE
me-17969: test if video on playlist by tag page is playing

### DIFF
--- a/test/e2e/components/videoComponent.ts
+++ b/test/e2e/components/videoComponent.ts
@@ -37,6 +37,8 @@ export class VideoComponent extends BaseComponent {
      * Pass `true` if the video is expected to be playing, or `false` if it is expected to be paused.
      */
     public async validateVideoIsPlaying(expectedPlaying: boolean): Promise<void> {
-        expect(await this.isPaused()).not.toEqual(expectedPlaying);
+        await expect(async () => {
+            expect(await this.isPaused()).not.toEqual(expectedPlaying);
+        }).toPass({ intervals: [500], timeout: 3000 });
     }
 }

--- a/test/e2e/specs/cldAnalyticsPage.spec.ts
+++ b/test/e2e/specs/cldAnalyticsPage.spec.ts
@@ -12,9 +12,7 @@ vpTest(`Test if 4 videos on Cloudinary analytics page are playing as expected`, 
         await waitForPageToLoadWithTimeout(page, 5000);
     });
     await test.step('Validating that Cloudinary analytics video is playing', async () => {
-        await expect(async () => {
-            await pomPages.cldAnalyticsPage.cldAnalyticsVideoComponent.validateVideoIsPlaying(true);
-        }).toPass({ intervals: [500], timeout: 3000 });
+        await pomPages.cldAnalyticsPage.cldAnalyticsVideoComponent.validateVideoIsPlaying(true);
     });
     await test.step('Validating that Cloudinary analytics ADP video is playing', async () => {
         await pomPages.cldAnalyticsPage.cldAnalyticsAdpVideoComponent.validateVideoIsPlaying(true);

--- a/test/e2e/specs/cldAnalyticsPage.spec.ts
+++ b/test/e2e/specs/cldAnalyticsPage.spec.ts
@@ -12,7 +12,9 @@ vpTest(`Test if 4 videos on Cloudinary analytics page are playing as expected`, 
         await waitForPageToLoadWithTimeout(page, 5000);
     });
     await test.step('Validating that Cloudinary analytics video is playing', async () => {
-        await pomPages.cldAnalyticsPage.cldAnalyticsVideoComponent.validateVideoIsPlaying(true);
+        await expect(async () => {
+            await pomPages.cldAnalyticsPage.cldAnalyticsVideoComponent.validateVideoIsPlaying(true);
+        }).toPass({ intervals: [500], timeout: 3000 });
     });
     await test.step('Validating that Cloudinary analytics ADP video is playing', async () => {
         await pomPages.cldAnalyticsPage.cldAnalyticsAdpVideoComponent.validateVideoIsPlaying(true);

--- a/test/e2e/specs/playlistByTagPage.spec.ts
+++ b/test/e2e/specs/playlistByTagPage.spec.ts
@@ -1,0 +1,17 @@
+import { vpTest } from '../fixtures/vpTest';
+import { test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../src/helpers/waitForPageToLoadWithTimeout';
+import { getLinkByName } from '../testData/pageLinksData';
+import { ExampleLinkName } from '../testData/ExampleLinkNames';
+
+const link = getLinkByName(ExampleLinkName.PlaylistByTag);
+
+vpTest.only(`Test if video on playlist by tag page is playing as expected`, async ({ page, pomPages }) => {
+    await test.step('Navigate to playlist by tag page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that playlist by tag video is playing', async () => {
+        await pomPages.playlistByTagPage.playlistByTagVideoComponent.validateVideoIsPlaying(true);
+    });
+});

--- a/test/e2e/specs/playlistByTagPage.spec.ts
+++ b/test/e2e/specs/playlistByTagPage.spec.ts
@@ -6,7 +6,7 @@ import { ExampleLinkName } from '../testData/ExampleLinkNames';
 
 const link = getLinkByName(ExampleLinkName.PlaylistByTag);
 
-vpTest.only(`Test if video on playlist by tag page is playing as expected`, async ({ page, pomPages }) => {
+vpTest(`Test if video on playlist by tag page is playing as expected`, async ({ page, pomPages }) => {
     await test.step('Navigate to playlist by tag page by clicking on link', async () => {
         await pomPages.mainPage.clickLinkByName(link.name);
         await waitForPageToLoadWithTimeout(page, 5000);

--- a/test/e2e/src/pom/PageManager.ts
+++ b/test/e2e/src/pom/PageManager.ts
@@ -17,6 +17,7 @@ import { FluidLayoutsPage } from './fluidLayoutsPage';
 import { ForceHlsSubtitlesPage } from './forceHlsSubtitlesPage';
 import { MultiplePlayersPage } from './multiplePlayersPage';
 import { PlaylistPage } from './playlistPage';
+import { PlaylistByTagPage } from './playlistByTagPage';
 
 /**
  * Page manager,
@@ -135,6 +136,10 @@ export class PageManager {
 
     public get playlistPage(): PlaylistPage {
         return this.getPage(PlaylistPage);
+    }
+
+    public get playlistByTagPage(): PlaylistByTagPage {
+        return this.getPage(PlaylistByTagPage);
     }
 }
 export default PageManager;

--- a/test/e2e/src/pom/playlistByTagPage.ts
+++ b/test/e2e/src/pom/playlistByTagPage.ts
@@ -1,0 +1,16 @@
+import { Page } from '@playwright/test';
+import { VideoComponent } from '../../components/videoComponent';
+import { BasePage } from './BasePage';
+const PLAYLIST_BY_TAG_PAGE_VIDEO_SELECTOR = '//*[@id="player_html5_api"]';
+
+/**
+ * Video player examples playlist by tag page object
+ */
+export class PlaylistByTagPage extends BasePage {
+    public playlistByTagVideoComponent: VideoComponent;
+
+    constructor(page: Page) {
+        super(page);
+        this.playlistByTagVideoComponent = new VideoComponent(page, PLAYLIST_BY_TAG_PAGE_VIDEO_SELECTOR);
+    }
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-17969
This test is navigating to playlist by tag page (playlist-by-tag-captions.html) and make sure that video element is playing.