### PR TITLE
me-18661: remove toPass wrap from existing specs

### DIFF
--- a/test/e2e/specs/autoplayOnScrollPage.spec.ts
+++ b/test/e2e/specs/autoplayOnScrollPage.spec.ts
@@ -1,5 +1,5 @@
 import { vpTest } from '../fixtures/vpTest';
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
 import { waitForPageToLoadWithTimeout } from '../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../testData/pageLinksData';
 import { ExampleLinkName } from '../testData/ExampleLinkNames';
@@ -23,8 +23,6 @@ vpTest(`Test if video on autoplay on scroll page is playing as expected`, async 
         await pomPages.autoplayOnScrollPage.autoplayOnScrollVideoComponent.locator.scrollIntoViewIfNeeded();
     });
     await test.step('Validating that the video is auto playing after scrolling', async () => {
-        await expect(async () => {
-            await pomPages.autoplayOnScrollPage.autoplayOnScrollVideoComponent.validateVideoIsPlaying(true);
-        }).toPass({ intervals: [500], timeout: 3000 });
+        await pomPages.autoplayOnScrollPage.autoplayOnScrollVideoComponent.validateVideoIsPlaying(true);
     });
 });

--- a/test/e2e/specs/chaptersPage.spec.ts
+++ b/test/e2e/specs/chaptersPage.spec.ts
@@ -1,5 +1,5 @@
 import { vpTest } from '../fixtures/vpTest';
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
 import { waitForPageToLoadWithTimeout } from '../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../testData/pageLinksData';
 import { ExampleLinkName } from '../testData/ExampleLinkNames';
@@ -21,8 +21,6 @@ vpTest(`Test if 3 videos on chapters page are playing as expected`, async ({ pag
         await pomPages.chaptersPage.chapterAutoVttFileVideoComponent.locator.scrollIntoViewIfNeeded();
     });
     await test.step('Validating that chapters auto vtt file video is playing', async () => {
-        await expect(async () => {
-            await pomPages.chaptersPage.chapterAutoVttFileVideoComponent.validateVideoIsPlaying(true);
-        }).toPass({ intervals: [500], timeout: 3000 });
+        await pomPages.chaptersPage.chapterAutoVttFileVideoComponent.validateVideoIsPlaying(true);
     });
 });

--- a/test/e2e/specs/cldAnalyticsPage.spec.ts
+++ b/test/e2e/specs/cldAnalyticsPage.spec.ts
@@ -1,5 +1,5 @@
 import { vpTest } from '../fixtures/vpTest';
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
 import { waitForPageToLoadWithTimeout } from '../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../testData/pageLinksData';
 import { ExampleLinkName } from '../testData/ExampleLinkNames';
@@ -21,16 +21,12 @@ vpTest(`Test if 4 videos on Cloudinary analytics page are playing as expected`, 
         await pomPages.cldAnalyticsPage.cldAnalyticsCustomDataObjectVideoComponent.locator.scrollIntoViewIfNeeded();
     });
     await test.step('Validating that Cloudinary analytics custom data object video is playing', async () => {
-        await expect(async () => {
-            await pomPages.cldAnalyticsPage.cldAnalyticsCustomDataObjectVideoComponent.validateVideoIsPlaying(true);
-        }).toPass({ intervals: [500], timeout: 3000 });
+        await pomPages.cldAnalyticsPage.cldAnalyticsCustomDataObjectVideoComponent.validateVideoIsPlaying(true);
     });
     await test.step('Scroll until Cloudinary analytics custom data function video element is visible', async () => {
         await pomPages.cldAnalyticsPage.cldAnalyticsCustomDataFunctionVideoComponent.locator.scrollIntoViewIfNeeded();
     });
     await test.step('Validating that Cloudinary analytics custom data function video is playing', async () => {
-        await expect(async () => {
-            await pomPages.cldAnalyticsPage.cldAnalyticsCustomDataFunctionVideoComponent.validateVideoIsPlaying(true);
-        }).toPass({ intervals: [500], timeout: 3000 });
+        await pomPages.cldAnalyticsPage.cldAnalyticsCustomDataFunctionVideoComponent.validateVideoIsPlaying(true);
     });
 });

--- a/test/e2e/specs/codecsAndFormats.spec.ts
+++ b/test/e2e/specs/codecsAndFormats.spec.ts
@@ -1,5 +1,5 @@
 import { vpTest } from '../fixtures/vpTest';
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
 import { waitForPageToLoadWithTimeout } from '../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../testData/pageLinksData';
 import { ExampleLinkName } from '../testData/ExampleLinkNames';
@@ -21,8 +21,6 @@ vpTest(`Test if 3 videos on codecs and formats page are playing as expected`, as
         await pomPages.codecsAndFormatsPage.codecsAndFormatsVp9VideoComponent.locator.scrollIntoViewIfNeeded();
     });
     await test.step('Validating that VP9 video is playing', async () => {
-        await expect(async () => {
-            await pomPages.codecsAndFormatsPage.codecsAndFormatsVp9VideoComponent.validateVideoIsPlaying(true);
-        }).toPass({ intervals: [500], timeout: 3000 });
+        await pomPages.codecsAndFormatsPage.codecsAndFormatsVp9VideoComponent.validateVideoIsPlaying(true);
     });
 });

--- a/test/e2e/specs/colorsApiPage.spec.ts
+++ b/test/e2e/specs/colorsApiPage.spec.ts
@@ -1,5 +1,5 @@
 import { vpTest } from '../fixtures/vpTest';
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
 import { waitForPageToLoadWithTimeout } from '../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../testData/pageLinksData';
 import { ExampleLinkName } from '../testData/ExampleLinkNames';
@@ -21,8 +21,6 @@ vpTest(`Test if 3 videos on colors API page are playing as expected`, async ({ p
         await pomPages.colorsApiPage.colorsApiLightSkinVideoComponent.locator.scrollIntoViewIfNeeded();
     });
     await test.step('Validating that light skin video is playing', async () => {
-        await expect(async () => {
-            await pomPages.colorsApiPage.colorsApiLightSkinVideoComponent.validateVideoIsPlaying(true);
-        }).toPass({ intervals: [500], timeout: 3000 });
+        await pomPages.colorsApiPage.colorsApiLightSkinVideoComponent.validateVideoIsPlaying(true);
     });
 });

--- a/test/e2e/specs/multiplePlayersPage.spec.ts
+++ b/test/e2e/specs/multiplePlayersPage.spec.ts
@@ -1,5 +1,5 @@
 import { vpTest } from '../fixtures/vpTest';
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
 import { waitForPageToLoadWithTimeout } from '../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../testData/pageLinksData';
 import { ExampleLinkName } from '../testData/ExampleLinkNames';
@@ -21,8 +21,6 @@ vpTest(`Test if 3 videos on multiple players page are playing as expected`, asyn
         await pomPages.colorsApiPage.colorsApiLightSkinVideoComponent.locator.scrollIntoViewIfNeeded();
     });
     await test.step('Validating that player 3 video is playing', async () => {
-        await expect(async () => {
-            await pomPages.multiplePlayersPage.multiplePlayersPlayer3VideoComponent.validateVideoIsPlaying(true);
-        }).toPass({ intervals: [500], timeout: 3000 });
+        await pomPages.multiplePlayersPage.multiplePlayersPlayer3VideoComponent.validateVideoIsPlaying(true);
     });
 });


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-18661
Some of the specs of checking if video is playing became flaky as it take some time to the video to start autoplay.
toPass wrap was added to validateVideoIsPlaying function.
This PR is to remove the toPass wrap from existing specs