### PR TITLE
me-17978: tests if videos are playing on vast and vpaid page

### DIFF
--- a/test/e2e/components/videoComponent.ts
+++ b/test/e2e/components/videoComponent.ts
@@ -34,11 +34,12 @@ export class VideoComponent extends BaseComponent {
      * Validates whether the video is currently playing.
      * This method uses the `isPaused` function to determine the current state of the video.
      * expectedPlaying - A boolean indicating the expected playback state of the video.
+     * timeout - Optional. The maximum time (in milliseconds) to wait for the validation. Defaults to 3000ms if not provided.
      * Pass `true` if the video is expected to be playing, or `false` if it is expected to be paused.
      */
-    public async validateVideoIsPlaying(expectedPlaying: boolean): Promise<void> {
+    public async validateVideoIsPlaying(expectedPlaying: boolean, timeout: number = 3000): Promise<void> {
         await expect(async () => {
             expect(await this.isPaused()).not.toEqual(expectedPlaying);
-        }).toPass({ intervals: [500], timeout: 3000 });
+        }).toPass({ intervals: [500], timeout });
     }
 }

--- a/test/e2e/specs/vastAndVpaidPage.spec.ts
+++ b/test/e2e/specs/vastAndVpaidPage.spec.ts
@@ -19,6 +19,6 @@ vpTest(`Test if 2 videos on vast and vpaid page are playing as expected`, async 
         await pomPages.vastAndVpaidPage.singleVideoWithAdsVideoComponent.validateVideoIsPlaying(true, 12000);
     });
     await test.step('Validating that playlist with ads video is playing', async () => {
-        await pomPages.vastAndVpaidPage.playlistWithAdsVideoComponent.validateVideoIsPlaying(true);
+        await pomPages.vastAndVpaidPage.playlistWithAdsVideoComponent.validateVideoIsPlaying(true, 12000);
     });
 });

--- a/test/e2e/specs/vastAndVpaidPage.spec.ts
+++ b/test/e2e/specs/vastAndVpaidPage.spec.ts
@@ -1,0 +1,24 @@
+import { vpTest } from '../fixtures/vpTest';
+import { test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../src/helpers/waitForPageToLoadWithTimeout';
+import { getLinkByName } from '../testData/pageLinksData';
+import { ExampleLinkName } from '../testData/ExampleLinkNames';
+
+const link = getLinkByName(ExampleLinkName.VASTAndVPAIDSupport);
+
+vpTest(`Test if 2 videos on vast and vpaid page are playing as expected`, async ({ page, pomPages }) => {
+    await test.step('Navigate to vast and vpaid page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Click on play button of single video with ads to play video', async () => {
+        return pomPages.vastAndVpaidPage.singleVideoWithAdsVideoComponent.clickPlay();
+    });
+    //Sending timeout of 12 seconds to wait until the ad finishes (10 sec) and the video will start
+    await test.step('Validating that single video with ads is playing', async () => {
+        await pomPages.vastAndVpaidPage.singleVideoWithAdsVideoComponent.validateVideoIsPlaying(true, 12000);
+    });
+    await test.step('Validating that playlist with ads video is playing', async () => {
+        await pomPages.vastAndVpaidPage.playlistWithAdsVideoComponent.validateVideoIsPlaying(true);
+    });
+});

--- a/test/e2e/src/pom/PageManager.ts
+++ b/test/e2e/src/pom/PageManager.ts
@@ -26,6 +26,7 @@ import { SeekThumbnailsPage } from './seekThumbnailsPage';
 import { ShoppableVideosPage } from './shoppableVideosPage';
 import { SubtitlesAndCaptionsPage } from './subtitlesAndCaptionsPage';
 import { VideoTransformationsPage } from './videoTransformationsPage';
+import { VastAndVpaidPage } from './vastAndVpaidPage';
 
 /**
  * Page manager,
@@ -180,6 +181,10 @@ export class PageManager {
 
     public get videoTransformationsPage(): VideoTransformationsPage {
         return this.getPage(VideoTransformationsPage);
+    }
+
+    public get vastAndVpaidPage(): VastAndVpaidPage {
+        return this.getPage(VastAndVpaidPage);
     }
 }
 export default PageManager;

--- a/test/e2e/src/pom/vastAndVpaidPage.ts
+++ b/test/e2e/src/pom/vastAndVpaidPage.ts
@@ -1,0 +1,19 @@
+import { Page } from '@playwright/test';
+import { VideoComponent } from '../../components/videoComponent';
+import { BasePage } from './BasePage';
+const SINGLE_VIDEO_WITH_ADS_VIDEO_SELECTOR = '//*[@id="player_html5_api"]';
+const PLAYLIST_WITH_ADS_VIDEO_SELECTOR = '//*[@id="player-playlist_html5_api"]';
+
+/**
+ * Video player examples vast and vpaid page object
+ */
+export class VastAndVpaidPage extends BasePage {
+    public singleVideoWithAdsVideoComponent: VideoComponent;
+    public playlistWithAdsVideoComponent: VideoComponent;
+
+    constructor(page: Page) {
+        super(page);
+        this.singleVideoWithAdsVideoComponent = new VideoComponent(page, SINGLE_VIDEO_WITH_ADS_VIDEO_SELECTOR);
+        this.playlistWithAdsVideoComponent = new VideoComponent(page, PLAYLIST_WITH_ADS_VIDEO_SELECTOR);
+    }
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-17978
This test is navigating to vast and vpaid page (vast-vpaid.html) and make sure that videos element are playing.
New optional parameter called `timeout` was added to `validateVideoIsPlaying` function because this page tests ads before videos and we need to wait minimum of 10 seconds until the ad finishes and the videos is starting. In all other cases `timeout` is set to default of 3 seconds.