### PR TITLE
me-18899: fix push report to repository in case of failure

### DIFF
--- a/.github/workflows/e2e_pr.yml
+++ b/.github/workflows/e2e_pr.yml
@@ -47,7 +47,6 @@ jobs:
          retention-days: 30
 
       - name: Pushes to reports repository
-        if: always()
         uses: cpina/github-action-push-to-another-repository@main
         env:
           API_TOKEN_GITHUB: ${{ secrets.BOT_TOKEN }}
@@ -59,5 +58,6 @@ jobs:
           target-branch: main
           target-directory: 'playwright-report_${{ github.run_id }}'
 
-      - name: Write URL in summary  
+      - name: Write URL in summary
+        if: always()
         run: echo "### Test results https://cloudinary.github.io/cloudinary-video-player-reports/playwright-report_${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/e2e_pr.yml
+++ b/.github/workflows/e2e_pr.yml
@@ -47,6 +47,7 @@ jobs:
          retention-days: 30
 
       - name: Pushes to reports repository
+        if: always()
         uses: cpina/github-action-push-to-another-repository@main
         env:
           API_TOKEN_GITHUB: ${{ secrets.BOT_TOKEN }}

--- a/test/e2e/specs/vastAndVpaidPage.spec.ts
+++ b/test/e2e/specs/vastAndVpaidPage.spec.ts
@@ -6,7 +6,7 @@ import { ExampleLinkName } from '../testData/ExampleLinkNames';
 
 const link = getLinkByName(ExampleLinkName.VASTAndVPAIDSupport);
 
-vpTest.only(`Test if 2 videos on vast and vpaid page are playing as expected`, async ({ page, pomPages }) => {
+vpTest(`Test if 2 videos on vast and vpaid page are playing as expected`, async ({ page, pomPages }) => {
     await test.step('Navigate to vast and vpaid page by clicking on link', async () => {
         await pomPages.mainPage.clickLinkByName(link.name);
         await waitForPageToLoadWithTimeout(page, 5000);

--- a/test/e2e/specs/vastAndVpaidPage.spec.ts
+++ b/test/e2e/specs/vastAndVpaidPage.spec.ts
@@ -6,7 +6,7 @@ import { ExampleLinkName } from '../testData/ExampleLinkNames';
 
 const link = getLinkByName(ExampleLinkName.VASTAndVPAIDSupport);
 
-vpTest(`Test if 2 videos on vast and vpaid page are playing as expected`, async ({ page, pomPages }) => {
+vpTest.only(`Test if 2 videos on vast and vpaid page are playing as expected`, async ({ page, pomPages }) => {
     await test.step('Navigate to vast and vpaid page by clicking on link', async () => {
         await pomPages.mainPage.clickLinkByName(link.name);
         await waitForPageToLoadWithTimeout(page, 5000);
@@ -16,7 +16,7 @@ vpTest(`Test if 2 videos on vast and vpaid page are playing as expected`, async 
     });
     //Sending timeout of 12 seconds to wait until the ad finishes (10 sec) and the video will start
     await test.step('Validating that single video with ads is playing', async () => {
-        await pomPages.vastAndVpaidPage.singleVideoWithAdsVideoComponent.validateVideoIsPlaying(true);
+        await pomPages.vastAndVpaidPage.singleVideoWithAdsVideoComponent.validateVideoIsPlaying(true, 12000);
     });
     await test.step('Validating that playlist with ads video is playing', async () => {
         await pomPages.vastAndVpaidPage.playlistWithAdsVideoComponent.validateVideoIsPlaying(true, 12000);

--- a/test/e2e/specs/vastAndVpaidPage.spec.ts
+++ b/test/e2e/specs/vastAndVpaidPage.spec.ts
@@ -16,7 +16,7 @@ vpTest(`Test if 2 videos on vast and vpaid page are playing as expected`, async 
     });
     //Sending timeout of 12 seconds to wait until the ad finishes (10 sec) and the video will start
     await test.step('Validating that single video with ads is playing', async () => {
-        await pomPages.vastAndVpaidPage.singleVideoWithAdsVideoComponent.validateVideoIsPlaying(true, 12000);
+        await pomPages.vastAndVpaidPage.singleVideoWithAdsVideoComponent.validateVideoIsPlaying(true);
     });
     await test.step('Validating that playlist with ads video is playing', async () => {
         await pomPages.vastAndVpaidPage.playlistWithAdsVideoComponent.validateVideoIsPlaying(true, 12000);


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-18899
Currently when the E2E fails the report is not being pushed to repository and not written in url summary.
This PR is to fix it and get it push on success and failure.