### PR TITLE
fix: Focus Visible (WCAG 2.4.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cloudinary.videoPlayer('player', {
 ## Documentation
 - [Documentation](https://cloudinary.com/documentation/cloudinary_video_player)
 - [API Reference](https://cloudinary.com/documentation/video_player_api_reference)
-- [Demo](https://demo.cloudinary.com/video-player/)
+- [Demos](https://cloudinary.com/demos?filter=videos)
 - [Code Examples](https://cloudinary.github.io/cloudinary-video-player/)
 - [Video Player Studio](https://studio.cloudinary.com/) 
 

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -7,7 +7,6 @@ $icon-font-path: '../icon-font' !default;
 
 // Import Video.js style
 @import '~video.root.js/dist/video-js.min.css';
-@include meta.load-css('mixins/skin');
 @include meta.load-css('icons');
 @include meta.load-css('components/loading-button.scss');
 @include meta.load-css('components/text-tracks.scss');
@@ -34,11 +33,12 @@ $icon-font-path: '../icon-font' !default;
 
   // focus and hover states
   .vjs-control,
-  .vjs-big-play-button,
   .vjs-icon-close,
   .vjs-volume-bar {
-    &:focus {
+    &:focus,
+    &:focus:before {
       outline: none;
+      text-shadow: 0 0 1em var(--color-text);
     }
   }
 

--- a/src/assets/styles/mixins/skin.scss
+++ b/src/assets/styles/mixins/skin.scss
@@ -1,7 +1,0 @@
-.cld-video-player.cld-video-player-skin- {
-  // light skin focus glow effect
-  .vjs-control:focus {
-    opacity: 1;
-    text-shadow: 0 0 1em var(--color-text);
-  }
-}


### PR DESCRIPTION
This PR fixes the Big Play Button focus indication along with better defaults for dark/light skins

Before:
<img width="304" alt="image" src="https://github.com/user-attachments/assets/5ce51bbc-069a-4101-852c-edcd4e1e3dee" />

After:
<img width="312" alt="image" src="https://github.com/user-attachments/assets/a82c5b73-8734-42ad-ad31-80d5b5535851" />
