### PR TITLE
fix: Non-text contrast (WCAG 1.4.11)

### DIFF
--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -255,6 +255,11 @@ $icon-font-path: '../icon-font' !default;
       &.vjs-volume-panel-horizontal {
         max-width: 8em;
       }
+
+      .vjs-slider {
+        background-color: color-mix(in srgb, var(--color-text) 10%, transparent);
+        box-shadow: 0 0 1px 1px color-mix(in srgb, var(--color-text) 80%, transparent) inset;
+      }
     }
 
     .vjs-progress-control {

--- a/src/plugins/colors/index.js
+++ b/src/plugins/colors/index.js
@@ -17,10 +17,6 @@ const playerColors = `
     background-color: --base-color;
   }
 
-  .PLAYER-CLASS-PREFIX .vjs-slider {
-    background-color: rgba(--text-color, 0.2);
-  }
-
   .PLAYER-CLASS-PREFIX .vjs-load-progress {
     background: rgba(--text-color, 0.3);
   }


### PR DESCRIPTION
This PR fixes an issue with the volume slider track color-contrast

Before:
<img width="243" alt="image" src="https://github.com/user-attachments/assets/0fcdfc1c-33f7-4b86-8031-f249b3b54d39" />

After:
<img width="272" alt="image" src="https://github.com/user-attachments/assets/29bb05d5-1a9f-46bf-9da1-54fc8119d7c3" />
