### PR TITLE
me-17983: test if video is playing on ESM examples main page

### DIFF
--- a/test/e2e/specs/ESM/esmMainPageVideoIsPlaying.spec.ts
+++ b/test/e2e/specs/ESM/esmMainPageVideoIsPlaying.spec.ts
@@ -1,10 +1,12 @@
 import { vpTest } from '../../fixtures/vpTest';
 import { testVideoIsPlaying } from '../commonSpecs/mainPageVideoPlaying';
+import { ESM_URL } from '../../testData/esmUrl';
 
 /**
  * Testing if video on main page is playing by checking that is pause return false.
  * The video in the main page is not configured as autoplay so first need to click on play button.
  */
-vpTest(`Test if video on main page can play as expected`, async ({ page, pomPages }) => {
+vpTest(`Test if video on ESM main page can play as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
     await testVideoIsPlaying(page, pomPages.mainPage.videoMainPage);
 });

--- a/test/e2e/specs/ESM/esmMainPageVideoIsPlaying.spec.ts
+++ b/test/e2e/specs/ESM/esmMainPageVideoIsPlaying.spec.ts
@@ -1,5 +1,5 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { testVideoIsPlaying } from '../commonSpecs/mainPageVideoPlaying';
+import { testMainPageVideoIsPlaying } from '../commonSpecs/mainPageVideoPlaying';
 import { ESM_URL } from '../../testData/esmUrl';
 
 /**
@@ -8,5 +8,5 @@ import { ESM_URL } from '../../testData/esmUrl';
  */
 vpTest(`Test if video on ESM main page can play as expected`, async ({ page, pomPages }) => {
     await page.goto(ESM_URL);
-    await testVideoIsPlaying(page, pomPages.mainPage.videoMainPage);
+    await testMainPageVideoIsPlaying(page, pomPages.mainPage.videoMainPage);
 });

--- a/test/e2e/specs/NonESM/mainPageVideoIsPlaying.spec.ts
+++ b/test/e2e/specs/NonESM/mainPageVideoIsPlaying.spec.ts
@@ -1,10 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { testVideoIsPlaying } from '../commonSpecs/mainPageVideoPlaying';
+import { testMainPageVideoIsPlaying } from '../commonSpecs/mainPageVideoPlaying';
 
 /**
  * Testing if video on main page is playing by checking that is pause return false.
  * The video in the main page is not configured as autoplay so first need to click on play button.
  */
 vpTest(`Test if video on main page can play as expected`, async ({ page, pomPages }) => {
-    await testVideoIsPlaying(page, pomPages.mainPage.videoMainPage);
+    await testMainPageVideoIsPlaying(page, pomPages.mainPage.videoMainPage);
 });

--- a/test/e2e/specs/commonSpecs/mainPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/mainPageVideoPlaying.ts
@@ -1,0 +1,13 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import { VideoComponent } from '../../components/videoComponent';
+
+export async function testVideoIsPlaying(page: Page, videoElement: VideoComponent) {
+    await test.step('Click on play button to play video', async () => {
+        await waitForPageToLoadWithTimeout(page, 5000);
+        return videoElement.clickPlay();
+    });
+    await test.step('Validating that the video is playing', async () => {
+        await videoElement.validateVideoIsPlaying(true);
+    });
+}

--- a/test/e2e/specs/commonSpecs/mainPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/mainPageVideoPlaying.ts
@@ -2,7 +2,7 @@ import { Page, test } from '@playwright/test';
 import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { VideoComponent } from '../../components/videoComponent';
 
-export async function testVideoIsPlaying(page: Page, videoElement: VideoComponent) {
+export async function testMainPageVideoIsPlaying(page: Page, videoElement: VideoComponent) {
     await test.step('Click on play button to play video', async () => {
         await waitForPageToLoadWithTimeout(page, 5000);
         return videoElement.clickPlay();


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-17983
This test is navigating to ESM main page and make sure that video element are playing.
As it share common steps as mainPageVideoIsPlaying.spec.ts that was already implemented I created common spec function testMainPageVideoIsPlaying and using it on both specs.