### PR TITLE
me-17985 test if video is playing on ESM highlights graph page

### DIFF
--- a/test/e2e/specs/ESM/esmHighlightsGraphPage.spec.ts
+++ b/test/e2e/specs/ESM/esmHighlightsGraphPage.spec.ts
@@ -1,0 +1,21 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import { ESM_URL } from '../../testData/esmUrl';
+
+const link = getEsmLinkByName(ExampleLinkName.HighlightsGraph);
+vpTest(`Test if video on ESM highlights graph page is playing as expected`, async ({ page, pomPages }) => {
+    await test.step('Navigate to ESM highlights graph page by clicking on link', async () => {
+        await page.goto(ESM_URL);
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Click on play button of video player to play video', async () => {
+        return pomPages.highlightGraphPage.videoHighlightsGraphPage.clickPlay();
+    });
+    await test.step('Validating that the video is playing', async () => {
+        await pomPages.highlightGraphPage.videoHighlightsGraphPage.validateVideoIsPlaying(true);
+    });
+});

--- a/test/e2e/specs/ESM/esmHighlightsGraphPage.spec.ts
+++ b/test/e2e/specs/ESM/esmHighlightsGraphPage.spec.ts
@@ -6,9 +6,12 @@ import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoa
 import { ESM_URL } from '../../testData/esmUrl';
 
 const link = getEsmLinkByName(ExampleLinkName.HighlightsGraph);
-vpTest(`Test if video on ESM highlights graph page is playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to ESM highlights graph page by clicking on link', async () => {
+
+vpTest.only(`Test if video on ESM highlights graph page is playing as expected`, async ({ page, pomPages }) => {
+    await test.step('Navigate to ESM', async () => {
         await page.goto(ESM_URL);
+    });
+    await test.step('Navigate to highlights graph page by clicking on link', async () => {
         await pomPages.mainPage.clickLinkByName(link.name);
         await waitForPageToLoadWithTimeout(page, 5000);
     });

--- a/test/e2e/specs/ESM/esmHighlightsGraphPage.spec.ts
+++ b/test/e2e/specs/ESM/esmHighlightsGraphPage.spec.ts
@@ -7,7 +7,7 @@ import { ESM_URL } from '../../testData/esmUrl';
 
 const link = getEsmLinkByName(ExampleLinkName.HighlightsGraph);
 
-vpTest.only(`Test if video on ESM highlights graph page is playing as expected`, async ({ page, pomPages }) => {
+vpTest(`Test if video on ESM highlights graph page is playing as expected`, async ({ page, pomPages }) => {
     await test.step('Navigate to ESM', async () => {
         await page.goto(ESM_URL);
     });


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-17985
This test is navigating to ESM highlights page (highlights-graph) and make sure that video element is playing.