### PR TITLE
me-17987: test if video is playing on ESM events and api page

### DIFF
--- a/test/e2e/specs/ESM/esmApiAndEventsPage.spec.ts
+++ b/test/e2e/specs/ESM/esmApiAndEventsPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ESM_URL } from '../../testData/esmUrl';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { testApiAndEventsPageVideoIsPlaying } from '../commonSpecs/apiAndEventsPageVideoPlaying';
+
+const link = getEsmLinkByName(ExampleLinkName.APIAndEvents);
+
+vpTest(`Test if video on ESM API and Events page can play as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testApiAndEventsPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/apiAndEventsPage.spec.ts
+++ b/test/e2e/specs/NonESM/apiAndEventsPage.spec.ts
@@ -1,20 +1,11 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testApiAndEventsPageVideoIsPlaying } from '../commonSpecs/apiAndEventsPageVideoPlaying';
 
 // Link to API and Events page
 const link = getLinkByName(ExampleLinkName.APIAndEvents);
-/**
- * Testing if video on API and Events page is playing by checking that is pause return false.
- */
+
 vpTest(`Test if video on API and Events page is playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to api and events page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Validating that the video is playing', async () => {
-        await pomPages.apiAndEventsPage.apiAndEventsVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testApiAndEventsPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/apiAndEventsPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/apiAndEventsPageVideoPlaying.ts
@@ -1,0 +1,14 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testApiAndEventsPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to api and events page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that the video is playing', async () => {
+        await pomPages.apiAndEventsPage.apiAndEventsVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-17987
This test is navigating to ESM events and API page and make sure that video element is playing.
As it share common steps as `apiAndEventsPage.spec.ts` that was already implemented I created common spec function `testApiAndEventsPageVideoIsPlaying` and using it on both specs.