### PR TITLE
ME-17988: test if videos are playing on audio player page

### DIFF
--- a/docs/es-modules/audio.html
+++ b/docs/es-modules/audio.html
@@ -24,7 +24,7 @@
 
       <h3 class="mb-4 mt-4">Audio Player - with transformations</h3>
 
-      <video id="player_t" playsinline controls class="cld-video-player" width="500"></video>
+      <video id="player-t" playsinline controls class="cld-video-player" width="500"></video>
 
       <p class="mt-4">
         <a href="https://cloudinary.com/documentation/cloudinary_video_player"
@@ -43,7 +43,7 @@
 
       player.source({ publicId: 'dog', sourceTypes: ['audio'] });
 
-      const player_t = videoPlayer('player_t', {
+      const player_t = videoPlayer('player-t', {
         cloudName: 'demo'
       });
 

--- a/test/e2e/specs/ESM/esmAudioPlayerPage.spec.ts
+++ b/test/e2e/specs/ESM/esmAudioPlayerPage.spec.ts
@@ -6,7 +6,7 @@ import { testAudioPlayerPageVideosArePlaying } from '../commonSpecs/audioPlayerP
 
 const link = getEsmLinkByName(ExampleLinkName.AudioPlayer);
 
-vpTest.only(`Test if video on ESM API and Events page can play as expected`, async ({ page, pomPages }) => {
+vpTest(`Test if video on ESM API and Events page can play as expected`, async ({ page, pomPages }) => {
     await page.goto(ESM_URL);
     await testAudioPlayerPageVideosArePlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/ESM/esmAudioPlayerPage.spec.ts
+++ b/test/e2e/specs/ESM/esmAudioPlayerPage.spec.ts
@@ -6,7 +6,7 @@ import { testAudioPlayerPageVideosArePlaying } from '../commonSpecs/audioPlayerP
 
 const link = getEsmLinkByName(ExampleLinkName.AudioPlayer);
 
-vpTest(`est if 2 videos on ESM audio player page are playing as expected`, async ({ page, pomPages }) => {
+vpTest(`Test if 2 videos on ESM audio player page are playing as expected`, async ({ page, pomPages }) => {
     await page.goto(ESM_URL);
     await testAudioPlayerPageVideosArePlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/ESM/esmAudioPlayerPage.spec.ts
+++ b/test/e2e/specs/ESM/esmAudioPlayerPage.spec.ts
@@ -6,7 +6,7 @@ import { testAudioPlayerPageVideosArePlaying } from '../commonSpecs/audioPlayerP
 
 const link = getEsmLinkByName(ExampleLinkName.AudioPlayer);
 
-vpTest(`Test if video on ESM API and Events page can play as expected`, async ({ page, pomPages }) => {
+vpTest(`est if 2 videos on ESM audio player page are playing as expected`, async ({ page, pomPages }) => {
     await page.goto(ESM_URL);
     await testAudioPlayerPageVideosArePlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/ESM/esmAudioPlayerPage.spec.ts
+++ b/test/e2e/specs/ESM/esmAudioPlayerPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ESM_URL } from '../../testData/esmUrl';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { testAudioPlayerPageVideosArePlaying } from '../commonSpecs/audioPlayerPageVideoPlaying';
+
+const link = getEsmLinkByName(ExampleLinkName.AudioPlayer);
+
+vpTest.only(`Test if video on ESM API and Events page can play as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testAudioPlayerPageVideosArePlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/audioPlayerPage.spec.ts
+++ b/test/e2e/specs/NonESM/audioPlayerPage.spec.ts
@@ -1,8 +1,7 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testAudioPlayerPageVideosArePlaying } from '../commonSpecs/audioPlayerPageVideoPlaying';
 
 // Link to audio player page
 const link = getLinkByName(ExampleLinkName.AudioPlayer);
@@ -10,20 +9,5 @@ const link = getLinkByName(ExampleLinkName.AudioPlayer);
  * Testing if videos on audio player page are playing by checking that is pause return false.
  */
 vpTest(`Test if 2 videos on audio player page are playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to audio player page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Click on play button of video player to play video', async () => {
-        return pomPages.audioPlayerPage.audioPlayerVideoComponent.clickPlay();
-    });
-    await test.step('Validating that the first video player is playing', async () => {
-        await pomPages.audioPlayerPage.audioPlayerVideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Click on play button of audio player with transformation to play video', async () => {
-        return pomPages.audioPlayerPage.audioPlayerWithTransformationVideoComponent.clickPlay();
-    });
-    await test.step('Validating that the audio player with transformation is playing', async () => {
-        await pomPages.audioPlayerPage.audioPlayerWithTransformationVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testAudioPlayerPageVideosArePlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/audioPlayerPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/audioPlayerPageVideoPlaying.ts
@@ -1,0 +1,23 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testAudioPlayerPageVideosArePlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to audio player page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Click on play button of video player to play video', async () => {
+        return pomPages.audioPlayerPage.audioPlayerVideoComponent.clickPlay();
+    });
+    await test.step('Validating that the first video player is playing', async () => {
+        await pomPages.audioPlayerPage.audioPlayerVideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Click on play button of audio player with transformation to play video', async () => {
+        return pomPages.audioPlayerPage.audioPlayerWithTransformationVideoComponent.clickPlay();
+    });
+    await test.step('Validating that the audio player with transformation is playing', async () => {
+        await pomPages.audioPlayerPage.audioPlayerWithTransformationVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-17988
This test is navigating to ESM audio player page and make sure that video elements are playing.
As it share common steps as `audioPlayerPage.spec.ts` that was already implemented I created common spec function `testAudioPlayerPageVideosArePlaying` and using it on both specs.