### PR TITLE
fix: live stream captions display

### DIFF
--- a/src/assets/styles/components/text-tracks.scss
+++ b/src/assets/styles/components/text-tracks.scss
@@ -2,29 +2,27 @@
   // Default captions styles
   // See styled-text-tracks plugin for more options
   .vjs-text-track-display {
-    margin: auto;
-    bottom: 0 !important;
-    > div {
-      margin: 3% !important;
-    }
+    // When control-bar is shown
+    bottom: 5em;
+    z-index: 2;
     // Word highlight
     &.cld-paced-text-tracks b {
       color: var(--color-accent);
     }
   }
+  &.vjs-controls-disabled .vjs-text-track-display,
+  &.vjs-user-inactive.vjs-playing .vjs-text-track-display {
+    // When control-bar is hidden/disabled
+    bottom: 1em;
+  }
+
   .vjs-text-track-cue {
-    top: auto !important;
-    // Position when control-bar is visible
-    bottom: 3.4rem !important;
+    max-width: 100%;
     > div {
       display: inline-block !important;
       padding: 0.1em 0.3em;
       background-color: rgba(0, 0, 0, 0.5) !important;
     }
-  }
-  &.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-text-track-cue {
-    // Position when control-bar is not visible
-    bottom: 1.5rem !important;
   }
 
   // Word highlight - default style

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -2,7 +2,7 @@
 $icon-font-path: '../icon-font' !default;
 
 // Video.js overrides
-@use "sass:meta";
+@use 'sass:meta';
 @use 'variables';
 
 // Import Video.js style
@@ -177,7 +177,7 @@ $icon-font-path: '../icon-font' !default;
   }
 
   &.vjs-error .vjs-error-display {
-    background: #90A0B3;
+    background: #90a0b3;
 
     &:before {
       display: none;
@@ -207,26 +207,37 @@ $icon-font-path: '../icon-font' !default;
   &.vjs-has-started .vjs-big-play-button,
   &.vjs-using-native-controls .vjs-big-play-button,
   &.vjs-error .vjs-big-play-button {
-    transition: visibility 0.2s, opacity 0.2s;
+    transition:
+      visibility 0.2s,
+      opacity 0.2s;
     display: block;
     visibility: hidden;
     opacity: 0;
   }
 
-  .vjs-progress-control.vjs-control {
-    &::before {
-      content: '';
-      pointer-events: none;
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      width: 100%;
-      height: 5rem;
-      background: linear-gradient(to bottom, transparent 0%, currentColor 100%);
-      opacity: 0.4;
-      z-index: 0;
-    }
+  &::before {
+    content: '';
+    pointer-events: none;
+    position: absolute;
+    bottom: 3em;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: 5rem;
+    background: linear-gradient(to bottom, transparent 0%, var(--color-base) 100%);
+    opacity: 0.4;
+    z-index: 1;
+    font-size: 120%;
+    display: none;
+  }
+  &.vjs-audio-only-mode::before,
+  &.vjs-has-started::before {
+    display: flex;
+    transition: opacity 0.1s;
+  }
+  &.vjs-has-started.vjs-user-inactive.vjs-playing::before {
+    opacity: 0;
+    transition: opacity 1s;
   }
 
   .vjs-control {
@@ -365,7 +376,7 @@ $icon-font-path: '../icon-font' !default;
             font-weight: 400;
             font-style: normal;
 
-            content: "\f131";
+            content: '\f131';
             display: block;
             position: absolute;
             width: 1em;


### PR DESCRIPTION
This PR fixes and improves our default styles for text-tracks (captions & subtitles).

1. fix: in live streams (but not only) it is possible to have multiple cues with the same time range, with our previous styles the would position on on top of the other, this change will fix that
2. improvement: previously our subtitles were positioned behind the control-bar shadow, this affected readability, with this change they are positioned above the shadow (but below the seek-thumbnails or the control-bar itself, which was tricky)
