### PR TITLE
Me 17989 esm autoplay on scroll page video playing

### DIFF
--- a/test/e2e/specs/ESM/esmAutoplayOnScroll.spec.ts
+++ b/test/e2e/specs/ESM/esmAutoplayOnScroll.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ESM_URL } from '../../testData/esmUrl';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { testAutoplayOnScrollPageVideoIsPlaying } from '../commonSpecs/autoplayOnScrollVideoPlaying';
+
+const link = getEsmLinkByName(ExampleLinkName.AutoplayOnScroll);
+
+vpTest(`Test if video on ESM autoplay on scroll page is playing as expected\``, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testAutoplayOnScrollPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/ESM/esmAutoplayOnScroll.spec.ts
+++ b/test/e2e/specs/ESM/esmAutoplayOnScroll.spec.ts
@@ -6,7 +6,7 @@ import { testAutoplayOnScrollPageVideoIsPlaying } from '../commonSpecs/autoplayO
 
 const link = getEsmLinkByName(ExampleLinkName.AutoplayOnScroll);
 
-vpTest(`Test if video on ESM autoplay on scroll page is playing as expected\``, async ({ page, pomPages }) => {
+vpTest(`Test if video on ESM autoplay on scroll page is playing as expected`, async ({ page, pomPages }) => {
     await page.goto(ESM_URL);
     await testAutoplayOnScrollPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/NonESM/autoplayOnScrollPage.spec.ts
+++ b/test/e2e/specs/NonESM/autoplayOnScrollPage.spec.ts
@@ -1,28 +1,11 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testAutoplayOnScrollPageVideoIsPlaying } from '../commonSpecs/autoplayOnScrollVideoPlaying';
 
 // Link to autoplay on scroll page
 const link = getLinkByName(ExampleLinkName.AutoplayOnScroll);
-/**
- * Testing if video on autoplay on scroll page is playing.
- * First making sure that video is not playing before scrolling.
- * Then, scroll until video element is visible and make sure video is playing by checking that is pause return false.
- */
+
 vpTest(`Test if video on autoplay on scroll page is playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to autoplay on scroll page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Validating that the video is not playing before scrolling', async () => {
-        await pomPages.autoplayOnScrollPage.autoplayOnScrollVideoComponent.validateVideoIsPlaying(false);
-    });
-    await test.step('Scroll until the video element is visible', async () => {
-        await pomPages.autoplayOnScrollPage.autoplayOnScrollVideoComponent.locator.scrollIntoViewIfNeeded();
-    });
-    await test.step('Validating that the video is auto playing after scrolling', async () => {
-        await pomPages.autoplayOnScrollPage.autoplayOnScrollVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testAutoplayOnScrollPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/autoplayOnScrollVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/autoplayOnScrollVideoPlaying.ts
@@ -1,0 +1,20 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testAutoplayOnScrollPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to autoplay on scroll page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that the video is not playing before scrolling', async () => {
+        await pomPages.autoplayOnScrollPage.autoplayOnScrollVideoComponent.validateVideoIsPlaying(false);
+    });
+    await test.step('Scroll until the video element is visible', async () => {
+        await pomPages.autoplayOnScrollPage.autoplayOnScrollVideoComponent.locator.scrollIntoViewIfNeeded();
+    });
+    await test.step('Validating that the video is auto playing after scrolling', async () => {
+        await pomPages.autoplayOnScrollPage.autoplayOnScrollVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-17989
This test is navigating to ESM autoplay on scroll and make sure that video element is playing.
As it share common steps as `autoplayOnScrollPage.spec.ts` that was already implemented I created common spec function `testAutoplayOnScrollPageVideoIsPlaying` and using it on both specs.