### PR TITLE
me-17990: test if videos are playing on ESM chapters page

### DIFF
--- a/test/e2e/specs/ESM/esmChaptersPage.spec.ts
+++ b/test/e2e/specs/ESM/esmChaptersPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ESM_URL } from '../../testData/esmUrl';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { testChaptersPageVideosArePlaying } from '../commonSpecs/chaptersPage';
+
+const link = getEsmLinkByName(ExampleLinkName.Chapters);
+
+vpTest(`Test if 3 videos on ESM chapters page are playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testChaptersPageVideosArePlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/chaptersPage.spec.ts
+++ b/test/e2e/specs/NonESM/chaptersPage.spec.ts
@@ -1,26 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testChaptersPageVideosArePlaying } from '../commonSpecs/chaptersPage';
 
 const link = getLinkByName(ExampleLinkName.Chapters);
 
 vpTest(`Test if 3 videos on chapters page are playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to chapters page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Validating that chapters vtt file video is playing', async () => {
-        await pomPages.chaptersPage.chaptersVttFIleVideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Validating that chapters config object video is playing', async () => {
-        await pomPages.chaptersPage.chaptersConfigObjectVideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Scroll until chapters auto vtt file video element is visible', async () => {
-        await pomPages.chaptersPage.chapterAutoVttFileVideoComponent.locator.scrollIntoViewIfNeeded();
-    });
-    await test.step('Validating that chapters auto vtt file video is playing', async () => {
-        await pomPages.chaptersPage.chapterAutoVttFileVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testChaptersPageVideosArePlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/chaptersPage.ts
+++ b/test/e2e/specs/commonSpecs/chaptersPage.ts
@@ -1,0 +1,23 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testChaptersPageVideosArePlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to chapters page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that chapters vtt file video is playing', async () => {
+        await pomPages.chaptersPage.chaptersVttFIleVideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Validating that chapters config object video is playing', async () => {
+        await pomPages.chaptersPage.chaptersConfigObjectVideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Scroll until chapters auto vtt file video element is visible', async () => {
+        await pomPages.chaptersPage.chapterAutoVttFileVideoComponent.locator.scrollIntoViewIfNeeded();
+    });
+    await test.step('Validating that chapters auto vtt file video is playing', async () => {
+        await pomPages.chaptersPage.chapterAutoVttFileVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-17990
This test is navigating to ESM chapters page and make sure that videos element are playing.
As it share common steps as `chaptersPage.spec.ts` that was already implemented I created common spec function `testChaptersPageVideosArePlaying` and using it on both specs.