### PR TITLE
me-17992: test if videos are playing on ESM codecs and formats page

### DIFF
--- a/test/e2e/specs/ESM/esmCodecsAndFormatsPage.spec.ts
+++ b/test/e2e/specs/ESM/esmCodecsAndFormatsPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { ESM_URL } from '../../testData/esmUrl';
+import { testCodecsAndFormatsPageVideoIsPlaying } from '../commonSpecs/codecsAndFormatsVideoPlaying';
+
+const link = getEsmLinkByName(ExampleLinkName.CodecsAndFormats);
+
+vpTest(`Test if 3 videos on ESM codecs and formats page are playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testCodecsAndFormatsPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/codecsAndFormats.spec.ts
+++ b/test/e2e/specs/NonESM/codecsAndFormats.spec.ts
@@ -1,26 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testCodecsAndFormatsPageVideoIsPlaying } from '../commonSpecs/codecsAndFormatsVideoPlaying';
 
 const link = getLinkByName(ExampleLinkName.CodecsAndFormats);
 
 vpTest(`Test if 3 videos on codecs and formats page are playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to codecs and formats page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Validating that f_auto video is playing', async () => {
-        await pomPages.codecsAndFormatsPage.codecsAndFormatsFAutoVideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Validating that AV1 video is playing', async () => {
-        await pomPages.codecsAndFormatsPage.codecsAndFormatsAv1VideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Scroll until VP9 video element is visible', async () => {
-        await pomPages.codecsAndFormatsPage.codecsAndFormatsVp9VideoComponent.locator.scrollIntoViewIfNeeded();
-    });
-    await test.step('Validating that VP9 video is playing', async () => {
-        await pomPages.codecsAndFormatsPage.codecsAndFormatsVp9VideoComponent.validateVideoIsPlaying(true);
-    });
+    await testCodecsAndFormatsPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/codecsAndFormatsVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/codecsAndFormatsVideoPlaying.ts
@@ -1,0 +1,23 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testCodecsAndFormatsPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to codecs and formats page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that f_auto video is playing', async () => {
+        await pomPages.codecsAndFormatsPage.codecsAndFormatsFAutoVideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Validating that AV1 video is playing', async () => {
+        await pomPages.codecsAndFormatsPage.codecsAndFormatsAv1VideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Scroll until VP9 video element is visible', async () => {
+        await pomPages.codecsAndFormatsPage.codecsAndFormatsVp9VideoComponent.locator.scrollIntoViewIfNeeded();
+    });
+    await test.step('Validating that VP9 video is playing', async () => {
+        await pomPages.codecsAndFormatsPage.codecsAndFormatsVp9VideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-17992
This test is navigating to ESM codecs and formats page and make sure that video elements are playing.
As it share common steps as `codecsAndFormats.spec.ts` that was already implemented I created common spec function `testCodecsAndFormatsPageVideoIsPlaying` and using it on both specs.