### PR TITLE
me-17994: test if video is playing on ESM components page

### DIFF
--- a/test/e2e/specs/ESM/esmComponentsPage.spec.ts
+++ b/test/e2e/specs/ESM/esmComponentsPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { ESM_URL } from '../../testData/esmUrl';
+import { testComponentsPageVideoIsPlaying } from '../commonSpecs/componentsPageVideoPlaying';
+
+const link = getEsmLinkByName(ExampleLinkName.Components);
+
+vpTest(`Test if video on ESM components page is playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testComponentsPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/componentsPage.spec.ts
+++ b/test/e2e/specs/NonESM/componentsPage.spec.ts
@@ -1,17 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testComponentsPageVideoIsPlaying } from '../commonSpecs/componentsPageVideoPlaying';
 
 const link = getLinkByName(ExampleLinkName.Components);
 
 vpTest(`Test if video on components page is playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to components page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Validating that components video is playing', async () => {
-        await pomPages.componentsPage.componentsVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testComponentsPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/componentsPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/componentsPageVideoPlaying.ts
@@ -1,0 +1,14 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testComponentsPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to components page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that components video is playing', async () => {
+        await pomPages.componentsPage.componentsVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-17994
This test is navigating to ESM components page and make sure that video element is playing.
As it share common steps as `componentsPage.spec.ts` that was already implemented I created common spec function `testComponentsPageVideoIsPlaying` and using it on both specs.