### PR TITLE
me-17995: test if video is playing on ESM display configuration page

### DIFF
--- a/docs/es-modules/ui-config.html
+++ b/docs/es-modules/ui-config.html
@@ -35,6 +35,7 @@
         crossorigin="anonymous"
         controls
         muted
+        autoplay
         playsinline
       ></video>
 

--- a/test/e2e/specs/ESM/esmDisplayConfigurationPage.spec.ts
+++ b/test/e2e/specs/ESM/esmDisplayConfigurationPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { ESM_URL } from '../../testData/esmUrl';
+import { testDisplayConfigurationPageVideoIsPlaying } from '../commonSpecs/displayConfigurationPageVideoPlaying';
+
+const link = getEsmLinkByName(ExampleLinkName.DisplayConfigurations);
+
+vpTest(`Test if video on ESM display configurations page is playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testDisplayConfigurationPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/displayConfigurationsPage.spec.ts
+++ b/test/e2e/specs/NonESM/displayConfigurationsPage.spec.ts
@@ -1,17 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testDisplayConfigurationPageVideoIsPlaying } from '../commonSpecs/displayConfigurationPageVideoPlaying';
 
 const link = getLinkByName(ExampleLinkName.DisplayConfigurations);
 
 vpTest(`Test if video on display configurations page is playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to display configurations page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Validating that display configuration video is playing', async () => {
-        await pomPages.displayConfigurationsPage.displayConfigurationsPageVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testDisplayConfigurationPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/displayConfigurationPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/displayConfigurationPageVideoPlaying.ts
@@ -1,0 +1,14 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testDisplayConfigurationPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to display configurations page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that display configuration video is playing', async () => {
+        await pomPages.displayConfigurationsPage.displayConfigurationsPageVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-17995
This test is navigating to ESM display configuration page and make sure that video element is playing.
As it share common steps as `displayConfigurationsPage.spec.ts` that was already implemented I created common spec function `testDisplayConfigurationPageVideoIsPlaying` and using it on both specs.
Also added autoplay attribute to video element on ESM display configuration page to be the same as the equivalent base example page (https://cloudinary.github.io/cloudinary-video-player/ui-config.html)