### PR TITLE
me-17996: test if video is playing on ESM floating player page

### DIFF
--- a/test/e2e/specs/ESM/esmFloatingPlayer.spec.ts
+++ b/test/e2e/specs/ESM/esmFloatingPlayer.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { ESM_URL } from '../../testData/esmUrl';
+import { testFloatingPlayerPageVideoIsPlaying } from '../commonSpecs/floatingPlayerPageVideoPlaying';
+
+const link = getEsmLinkByName(ExampleLinkName.FloatingPlayer);
+
+vpTest(`Test if video on ESM floating player page is playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testFloatingPlayerPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/floatingPlayerPgae.spec.ts
+++ b/test/e2e/specs/NonESM/floatingPlayerPgae.spec.ts
@@ -1,17 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testFloatingPlayerPageVideoIsPlaying } from '../commonSpecs/floatingPlayerPageVideoPlaying';
 
 const link = getLinkByName(ExampleLinkName.FloatingPlayer);
 
 vpTest(`Test if video on floating player page is playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to floating player page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Validating that floating player video is playing', async () => {
-        await pomPages.floatingPlayerPage.floatingPlayerVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testFloatingPlayerPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/floatingPlayerPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/floatingPlayerPageVideoPlaying.ts
@@ -1,0 +1,14 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testFloatingPlayerPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to floating player page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that floating player video is playing', async () => {
+        await pomPages.floatingPlayerPage.floatingPlayerVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-17996
This test is navigating to ESM floating player page and make sure that video element is playing.
As it share common steps as `floatingPlayerPage.spec.ts` that was already implemented I created common spec function `testFloatingPlayerPageVideoIsPlaying` and using it on both specs.
