### PR TITLE
me-17997: test if video is playing on ESM fluid layouts page

### DIFF
--- a/test/e2e/specs/ESM/esmFluidLayoutsPage.spec.ts
+++ b/test/e2e/specs/ESM/esmFluidLayoutsPage.spec.ts
@@ -2,9 +2,11 @@ import { vpTest } from '../../fixtures/vpTest';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
 import { testFluidLayoutsPageVideoIsPlaying } from '../commonSpecs/fluidLayoutsPageVideoPlaying';
+import { ESM_URL } from '../../testData/esmUrl';
 
 const link = getLinkByName(ExampleLinkName.FluidLayouts);
 
-vpTest(`Test if video on fluid layouts page is playing as expected`, async ({ page, pomPages }) => {
+vpTest(`Test if video on ESM fluid layouts page is playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
     await testFluidLayoutsPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/fluidLayoutsPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/fluidLayoutsPageVideoPlaying.ts
@@ -1,0 +1,14 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testFluidLayoutsPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to fluid layouts page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that fluid layouts video is playing', async () => {
+        await pomPages.fluidLayoutsPage.fluidLayoutsVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-17997
This test is navigating to ESM fluid layouts player page and make sure that video element is playing.
As it share common steps as `fluidLayoutsPage.spec.ts` that was already implemented I created common spec function `testFluidLayoutsPageVideoIsPlaying` and using it on both specs.