### PR TITLE
me-17998: test if video is playing on ESM force HLS subtitles page

### DIFF
--- a/docs/es-modules/force-hls-subtitles.html
+++ b/docs/es-modules/force-hls-subtitles.html
@@ -25,6 +25,7 @@
         crossorigin="anonymous"
         controls
         muted
+        autoplay
         playsinline
       ></video>
 

--- a/test/e2e/specs/ESM/esmForceHlsSubtitlesPage.spec.ts
+++ b/test/e2e/specs/ESM/esmForceHlsSubtitlesPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testForceHlsSubtitlesPageVideoIsPlaying } from '../commonSpecs/forceHlsSubtitlesPageVideoPlaying';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { ESM_URL } from '../../testData/esmUrl';
+
+const link = getEsmLinkByName(ExampleLinkName.ForceHLSSubtitles);
+
+vpTest(`Test if video on ESM force HLS subtitles page is playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testForceHlsSubtitlesPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/forceHlsSubtitlesPage.spec.ts
+++ b/test/e2e/specs/NonESM/forceHlsSubtitlesPage.spec.ts
@@ -1,17 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testForceHlsSubtitlesPageVideoIsPlaying } from '../commonSpecs/forceHlsSubtitlesPageVideoPlaying';
 
 const link = getLinkByName(ExampleLinkName.ForceHLSSubtitles);
 
 vpTest(`Test if video on force HLS subtitles page is playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to force HLS subtitles page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Validating that force HLS subtitles video is playing', async () => {
-        await pomPages.forceHlsSubtitlesPage.forceHlsSubtitlesVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testForceHlsSubtitlesPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/forceHlsSubtitlesPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/forceHlsSubtitlesPageVideoPlaying.ts
@@ -1,0 +1,14 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testForceHlsSubtitlesPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to force HLS subtitles page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that force HLS subtitles video is playing', async () => {
+        await pomPages.forceHlsSubtitlesPage.forceHlsSubtitlesVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-17998
This test is navigating to ESM force HLS subtitles page and make sure that video element is playing.
As it share common steps as `forceHlsSubtitlesPage.spec.ts `that was already implemented I created common spec function `testForceHlsSubtitlesPageVideoIsPlaying` and using it on both specs.
Also added autoplay attribute to video element on ESM force HLS subtitles page page to be the same as the equivalent base example page (https://cloudinary.github.io/cloudinary-video-player/force-hls-subtitles-ios.html)