### PR TITLE
me-17999: test if videos are playing on ESM multiple players page

### DIFF
--- a/docs/es-modules/multiple-players.html
+++ b/docs/es-modules/multiple-players.html
@@ -28,6 +28,7 @@
           playsinline
           data-cld-public-id="elephants"
           class="cld-video-player cld-video-player-skin-dark"
+          id="player-1"
         ></video>
       </div>
 
@@ -38,6 +39,7 @@
           playsinline
           data-cld-public-id="marmots"
           class="cld-video-player cld-video-player-skin-light"
+          id="player-2"
         ></video>
       </div>
 
@@ -48,6 +50,7 @@
           playsinline
           data-cld-public-id="snow_deer_short"
           class="cld-video-player"
+          id="player-3"
         ></video>
       </div>
 

--- a/test/e2e/specs/ESM/esmMultiplePlayersPage.spec.ts
+++ b/test/e2e/specs/ESM/esmMultiplePlayersPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testMultiplePlayersPageVideoIsPlaying } from '../commonSpecs/multiplePlayersPageVideoPlaying';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { ESM_URL } from '../../testData/esmUrl';
+
+const link = getEsmLinkByName(ExampleLinkName.MultiplePlayers);
+
+vpTest(`Test if 3 videos on ESM multiple players page are playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testMultiplePlayersPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/multiplePlayersPage.spec.ts
+++ b/test/e2e/specs/NonESM/multiplePlayersPage.spec.ts
@@ -1,26 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testMultiplePlayersPageVideoIsPlaying } from '../commonSpecs/multiplePlayersPageVideoPlaying';
 
 const link = getLinkByName(ExampleLinkName.MultiplePlayers);
 
 vpTest(`Test if 3 videos on multiple players page are playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to multiple players page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Validating that player 1 video is playing', async () => {
-        await pomPages.multiplePlayersPage.multiplePlayersPlayer1VideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Validating that player 2 video video is playing', async () => {
-        await pomPages.multiplePlayersPage.multiplePlayersPlayer2VideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Scroll until player 3 video element is visible', async () => {
-        await pomPages.colorsApiPage.colorsApiLightSkinVideoComponent.locator.scrollIntoViewIfNeeded();
-    });
-    await test.step('Validating that player 3 video is playing', async () => {
-        await pomPages.multiplePlayersPage.multiplePlayersPlayer3VideoComponent.validateVideoIsPlaying(true);
-    });
+    await testMultiplePlayersPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/multiplePlayersPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/multiplePlayersPageVideoPlaying.ts
@@ -1,0 +1,23 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testMultiplePlayersPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to multiple players page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that player 1 video is playing', async () => {
+        await pomPages.multiplePlayersPage.multiplePlayersPlayer1VideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Validating that player 2 video video is playing', async () => {
+        await pomPages.multiplePlayersPage.multiplePlayersPlayer2VideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Scroll until player 3 video element is visible', async () => {
+        await pomPages.colorsApiPage.colorsApiLightSkinVideoComponent.locator.scrollIntoViewIfNeeded();
+    });
+    await test.step('Validating that player 3 video is playing', async () => {
+        await pomPages.multiplePlayersPage.multiplePlayersPlayer3VideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-17999
This test is navigating to ESM multiple players page and make sure that video elements are playing.
As it share common steps as `multiplePlayersPage.spec.ts` that was already implemented I created common spec function `testMultiplePlayersPageVideoIsPlaying` and using it on both specs.
Also added id's to videos elements on ESM multiple players page be the same as the equivalent base example page (https://cloudinary.github.io/cloudinary-video-player/multiple-players)