### PR TITLE
me-18000: test if videos are playing on ESM playlist page

### DIFF
--- a/test/e2e/specs/ESM/esmPlaylistPage.spec.ts
+++ b/test/e2e/specs/ESM/esmPlaylistPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testPlaylistPageVideoIsPlaying } from '../commonSpecs/playlistPageVideoPlaying';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { ESM_URL } from '../../testData/esmUrl';
+
+const link = getEsmLinkByName(ExampleLinkName.Playlist);
+
+vpTest(`Test if 2 videos on ESM playlist page are playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testPlaylistPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/playlistPage.spec.ts
+++ b/test/e2e/specs/NonESM/playlistPage.spec.ts
@@ -1,20 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testPlaylistPageVideoIsPlaying } from '../commonSpecs/playlistPageVideoPlaying';
 
 const link = getLinkByName(ExampleLinkName.Playlist);
 
 vpTest(`Test if 2 videos on playlist page are playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to playlist page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Validating that horizontal playlist video is playing', async () => {
-        await pomPages.playlistPage.playlistHorizontalVideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Validating that vertical playlist video is playing', async () => {
-        await pomPages.playlistPage.playlistVerticalVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testPlaylistPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/playlistPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/playlistPageVideoPlaying.ts
@@ -1,0 +1,17 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testPlaylistPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to playlist page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that horizontal playlist video is playing', async () => {
+        await pomPages.playlistPage.playlistHorizontalVideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Validating that vertical playlist video is playing', async () => {
+        await pomPages.playlistPage.playlistVerticalVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-18000
This test is navigating to ESM playlist page and make sure that video elements are playing.
As it share common steps as `playlistPage.spec.ts` that was already implemented I created common spec function `testPlaylistPageVideoIsPlaying` and using it on both specs.