### PR TITLE
me-18001: test if video is playing on ESM playlist by tag page

### DIFF
--- a/test/e2e/specs/ESM/esmPlaylistByTag.spec.ts
+++ b/test/e2e/specs/ESM/esmPlaylistByTag.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { testPlaylistByTagPageVideoIsPlaying } from '../commonSpecs/playlistByTagPageVideoPlaying';
+import { ESM_URL } from '../../testData/esmUrl';
+
+const link = getEsmLinkByName(ExampleLinkName.PlaylistByTag);
+
+vpTest(`Test if video on ESM playlist by tag page is playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testPlaylistByTagPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/playlistByTagPage.spec.ts
+++ b/test/e2e/specs/NonESM/playlistByTagPage.spec.ts
@@ -1,17 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testPlaylistByTagPageVideoIsPlaying } from '../commonSpecs/playlistByTagPageVideoPlaying';
 
 const link = getLinkByName(ExampleLinkName.PlaylistByTag);
 
 vpTest(`Test if video on playlist by tag page is playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to playlist by tag page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Validating that playlist by tag video is playing', async () => {
-        await pomPages.playlistByTagPage.playlistByTagVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testPlaylistByTagPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/playlistByTagPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/playlistByTagPageVideoPlaying.ts
@@ -1,0 +1,14 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testPlaylistByTagPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to playlist by tag page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that playlist by tag video is playing', async () => {
+        await pomPages.playlistByTagPage.playlistByTagVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-18001
This test is navigating to ESM playlist by tag page and make sure that video element is playing.
As it share common steps as `playlistByTagPage.spec.ts` that was already implemented I created common spec function `testPlaylistByTagPageVideoIsPlaying` and using it on both specs.