### PR TITLE
me-18002: test if videos are playing on ESM poster options page

### DIFF
--- a/test/e2e/specs/ESM/esmPosterOptionsPage.spec.ts
+++ b/test/e2e/specs/ESM/esmPosterOptionsPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testPosterOptionsPageVideoIsPlaying } from '../commonSpecs/posterOptionsPage';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { ESM_URL } from '../../testData/esmUrl';
+
+const link = getEsmLinkByName(ExampleLinkName.PosterOptions);
+
+vpTest(`Test if 4 videos on ESM poster options page are playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testPosterOptionsPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/posterOptionsPage.spec.ts
+++ b/test/e2e/specs/NonESM/posterOptionsPage.spec.ts
@@ -1,38 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testPosterOptionsPageVideoIsPlaying } from '../commonSpecs/posterOptionsPage';
 
 const link = getLinkByName(ExampleLinkName.PosterOptions);
 
 vpTest(`Test if 4 videos on poster options page are playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to poster options page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Click on play button of custom image poster player to play video', async () => {
-        return pomPages.posterOptionsPage.posterOptionsCustomImageVideoComponent.clickPlay();
-    });
-    await test.step('Validating that the custom image poster video is playing', async () => {
-        await pomPages.posterOptionsPage.posterOptionsCustomImageVideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Click on play button of specific frame poster player to play video', async () => {
-        return pomPages.posterOptionsPage.posterOptionsSpecificFrameVideoComponent.clickPlay();
-    });
-    await test.step('Validating that specific frame poster video is playing', async () => {
-        await pomPages.posterOptionsPage.posterOptionsSpecificFrameVideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Click on play button of transformations array poster player to play video', async () => {
-        return pomPages.posterOptionsPage.posterOptionsTransformationsArrayVideoComponent.clickPlay();
-    });
-    await test.step('Validating that transformations array poster video is playing', async () => {
-        await pomPages.posterOptionsPage.posterOptionsTransformationsArrayVideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Click on play button of raw url no poster player to play video', async () => {
-        return pomPages.posterOptionsPage.posterOptionsRawUrlNoPosterVideoComponent.clickPlay();
-    });
-    await test.step('Validating that raw url no poster video is playing', async () => {
-        await pomPages.posterOptionsPage.posterOptionsRawUrlNoPosterVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testPosterOptionsPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/posterOptionsPage.ts
+++ b/test/e2e/specs/commonSpecs/posterOptionsPage.ts
@@ -1,0 +1,35 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testPosterOptionsPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to poster options page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Click on play button of custom image poster player to play video', async () => {
+        return pomPages.posterOptionsPage.posterOptionsCustomImageVideoComponent.clickPlay();
+    });
+    await test.step('Validating that the custom image poster video is playing', async () => {
+        await pomPages.posterOptionsPage.posterOptionsCustomImageVideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Click on play button of specific frame poster player to play video', async () => {
+        return pomPages.posterOptionsPage.posterOptionsSpecificFrameVideoComponent.clickPlay();
+    });
+    await test.step('Validating that specific frame poster video is playing', async () => {
+        await pomPages.posterOptionsPage.posterOptionsSpecificFrameVideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Click on play button of transformations array poster player to play video', async () => {
+        return pomPages.posterOptionsPage.posterOptionsTransformationsArrayVideoComponent.clickPlay();
+    });
+    await test.step('Validating that transformations array poster video is playing', async () => {
+        await pomPages.posterOptionsPage.posterOptionsTransformationsArrayVideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Click on play button of raw url no poster player to play video', async () => {
+        return pomPages.posterOptionsPage.posterOptionsRawUrlNoPosterVideoComponent.clickPlay();
+    });
+    await test.step('Validating that raw url no poster video is playing', async () => {
+        await pomPages.posterOptionsPage.posterOptionsRawUrlNoPosterVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-18002
This test is navigating to ESM poster options page and make sure that video elements are playing.
As it share common steps as p`osterOptionsPage.spec.ts` that was already implemented I created common spec function `testPosterOptionsPageVideoIsPlaying` and using it on both specs.