### PR TITLE
me-18003: test if videos are playing on ESM profiles page

### DIFF
--- a/test/e2e/specs/ESM/esmProfilesPage.spec.ts
+++ b/test/e2e/specs/ESM/esmProfilesPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testProfilesPageVideoIsPlaying } from '../commonSpecs/profilesPageVideoPlaying';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { ESM_URL } from '../../testData/esmUrl';
+
+const link = getEsmLinkByName(ExampleLinkName.Profiles);
+
+vpTest(`Test if 3 videos on ESM profiles page are playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testProfilesPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/profilesPage.spec.ts
+++ b/test/e2e/specs/NonESM/profilesPage.spec.ts
@@ -1,29 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testProfilesPageVideoIsPlaying } from '../commonSpecs/profilesPageVideoPlaying';
 
 const link = getLinkByName(ExampleLinkName.Profiles);
 
 vpTest(`Test if 3 videos on profiles page are playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to profiles page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Validating that default profile video is playing', async () => {
-        await pomPages.profilesPage.profilesDefaultProfileVideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Scroll until custom profile video element is visible', async () => {
-        await pomPages.profilesPage.profilesCustomProfileVideoComponent.locator.scrollIntoViewIfNeeded();
-    });
-    await test.step('Validating that custom profile video is playing', async () => {
-        await pomPages.profilesPage.profilesCustomProfileVideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Scroll until custom profile overrides video element is visible', async () => {
-        await pomPages.profilesPage.profilesCustomProfileOverridesVideoComponent.locator.scrollIntoViewIfNeeded();
-    });
-    await test.step('Validating that custom profile overrides video is playing', async () => {
-        await pomPages.profilesPage.profilesCustomProfileOverridesVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testProfilesPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/profilesPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/profilesPageVideoPlaying.ts
@@ -1,0 +1,26 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testProfilesPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to profiles page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that default profile video is playing', async () => {
+        await pomPages.profilesPage.profilesDefaultProfileVideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Scroll until custom profile video element is visible', async () => {
+        await pomPages.profilesPage.profilesCustomProfileVideoComponent.locator.scrollIntoViewIfNeeded();
+    });
+    await test.step('Validating that custom profile video is playing', async () => {
+        await pomPages.profilesPage.profilesCustomProfileVideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Scroll until custom profile overrides video element is visible', async () => {
+        await pomPages.profilesPage.profilesCustomProfileOverridesVideoComponent.locator.scrollIntoViewIfNeeded();
+    });
+    await test.step('Validating that custom profile overrides video is playing', async () => {
+        await pomPages.profilesPage.profilesCustomProfileOverridesVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-18003
This test is navigating to ESM profiles page and make sure that video elements are playing.
As it share common steps as `profilesPage.spec.ts` that was already implemented I created common spec function `testProfilesPageVideoIsPlaying` and using it on both specs.