### PR TITLE
me-18004: test if videos are playing on ESM raw url page

### DIFF
--- a/docs/es-modules/raw-url.html
+++ b/docs/es-modules/raw-url.html
@@ -34,7 +34,7 @@
       <h3 class="mb-4">Video with raw URL - ABR</h3>
 
       <video
-        id="abrPlayer"
+        id="adpPlayer"
         playsinline
         controls
         muted
@@ -65,9 +65,9 @@
 
       player.source('https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4');
 
-      const abrPlayer = videoPlayer('abrPlayer', config);
+      const adpPlayer = videoPlayer('adpPlayer', config);
 
-      abrPlayer.source('https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8');
+      adpPlayer.source('https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8');
     </script>
 
     <!-- Bootstrap -->

--- a/test/e2e/specs/ESM/esmRawUrlPage.spec.ts
+++ b/test/e2e/specs/ESM/esmRawUrlPage.spec.ts
@@ -6,7 +6,7 @@ import { ESM_URL } from '../../testData/esmUrl';
 
 const link = getEsmLinkByName(ExampleLinkName.RawURL);
 
-vpTest.only(`Test if 2 videos on ESM raw URL page are playing as expected`, async ({ page, pomPages }) => {
+vpTest(`Test if 2 videos on ESM raw URL page are playing as expected`, async ({ page, pomPages }) => {
     await page.goto(ESM_URL);
     await testRawUrlPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/ESM/esmRawUrlPage.spec.ts
+++ b/test/e2e/specs/ESM/esmRawUrlPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testRawUrlPageVideoIsPlaying } from '../commonSpecs/rawUrlPageVideoPlaying';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { ESM_URL } from '../../testData/esmUrl';
+
+const link = getEsmLinkByName(ExampleLinkName.RawURL);
+
+vpTest.only(`Test if 2 videos on ESM raw URL page are playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testRawUrlPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/rawUrlPage.spec.ts
+++ b/test/e2e/specs/NonESM/rawUrlPage.spec.ts
@@ -1,20 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testRawUrlPageVideoIsPlaying } from '../commonSpecs/rawUrlPageVideoPlaying';
 
 const link = getLinkByName(ExampleLinkName.RawURL);
 
 vpTest(`Test if 2 videos on raw URL page are playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to raw URL page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Validating that raw url video is playing', async () => {
-        await pomPages.rawUrlPage.rawUrlVideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Validating that raw url adaptive video is playing', async () => {
-        await pomPages.rawUrlPage.rawUrlAdaptiveVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testRawUrlPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/rawUrlPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/rawUrlPageVideoPlaying.ts
@@ -1,0 +1,17 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testRawUrlPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to raw URL page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that raw url video is playing', async () => {
+        await pomPages.rawUrlPage.rawUrlVideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Validating that raw url adaptive video is playing', async () => {
+        await pomPages.rawUrlPage.rawUrlAdaptiveVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-18004
This test is navigating to ESM raw URL and make sure that video elements are playing.
As it share common steps as `rawUrlPage.spec.ts` that was already implemented I created common spec function `testRawUrlPageVideoIsPlaying` and using it on both specs.
Also changed id's of ADP video element to be the same as the equivalent base example page