### PR TITLE
me-18005: test if video is playing on recommendations page

### DIFF
--- a/docs/es-modules/recommendations.html
+++ b/docs/es-modules/recommendations.html
@@ -25,6 +25,7 @@
         crossorigin="anonymous"
         controls
         muted
+        autoplay
         playsinline
       ></video>
 

--- a/test/e2e/specs/ESM/esmRecommendationsPage.spec.ts
+++ b/test/e2e/specs/ESM/esmRecommendationsPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testRecommendationsPageVideoIsPlaying } from '../commonSpecs/recommendationsPageVideoPlaying';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { ESM_URL } from '../../testData/esmUrl';
+
+const link = getEsmLinkByName(ExampleLinkName.Recommendations);
+
+vpTest(`Test if video on ESM recommendations page is playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testRecommendationsPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/recommendationsPage.spec.ts
+++ b/test/e2e/specs/NonESM/recommendationsPage.spec.ts
@@ -1,17 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testRecommendationsPageVideoIsPlaying } from '../commonSpecs/recommendationsPageVideoPlaying';
 
 const link = getLinkByName(ExampleLinkName.Recommendations);
 
 vpTest(`Test if video on recommendations page is playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to recommendations page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Validating that recommendations video is playing', async () => {
-        await pomPages.recommendationsPage.recommendationsVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testRecommendationsPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/recommendationsPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/recommendationsPageVideoPlaying.ts
@@ -1,0 +1,14 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testRecommendationsPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to recommendations page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that recommendations video is playing', async () => {
+        await pomPages.recommendationsPage.recommendationsVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-18005
This test is navigating to ESM recommendations page and make sure that video element is playing.
As it share common steps as `recommendationsPage.spec.ts` that was already implemented I created common spec function `testRecommendationsPageVideoIsPlaying` and using it on both specs.
Also added autoplay attribute to video element to be the same as the equivalent base example page