### PR TITLE
fix: update quality selector check icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "lodash": "^4.17.21",
         "srt-parser-2": "^1.2.3",
         "uuid": "^11.0.3",
-        "video.js": "^8.21.0",
+        "video.js": "^8.23.3",
         "videojs-contrib-ads": "^7.5.2",
         "videojs-contrib-dash": "^5.1.1",
         "videojs-ima": "^2.3.0",
@@ -4395,9 +4395,9 @@
       }
     },
     "node_modules/@videojs/http-streaming": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.16.2.tgz",
-      "integrity": "sha512-fvt4ko7FknxiT9FnjyNQt6q2px+awrkM+Orv7IB/4gldvj94u4fowGfmNHynnvNTPgPkdxHklGmFLGfclYw8HA==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.17.0.tgz",
+      "integrity": "sha512-Ch1P3tvvIEezeZXyK11UfWgp4cWKX4vIhZ30baN/lRinqdbakZ5hiAI3pGjRy3d+q/Epyc8Csz5xMdKNNGYpcw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -16427,13 +16427,13 @@
       }
     },
     "node_modules/video.js": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.21.0.tgz",
-      "integrity": "sha512-zcwerRb257QAuWfi8NH9yEX7vrGKFthjfcONmOQ4lxFRpDAbAi+u5LAjCjMWqhJda6zEmxkgdDpOMW3Y21QpXA==",
+      "version": "8.23.3",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.23.3.tgz",
+      "integrity": "sha512-Toe0VLlDZcUhiaWfcePS1OEdT3ATfktm0hk/PELfD7zUoPDHeT+cJf/wZmCy5M5eGVwtGUg25RWPCj1L/1XufA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/http-streaming": "^3.16.2",
+        "@videojs/http-streaming": "^3.17.0",
         "@videojs/vhs-utils": "^4.1.1",
         "@videojs/xhr": "2.7.0",
         "aes-decrypter": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "files": [
       {
         "path": "./dist/cld-video-player.min.js",
-        "maxSize": "258kb"
+        "maxSize": "260kb"
       },
       {
         "path": "./dist/cld-video-player.light.min.js",
@@ -71,11 +71,11 @@
       },
       {
         "path": "./lib/cld-video-player.js",
-        "maxSize": "258kb"
+        "maxSize": "260kb"
       },
       {
         "path": "./lib/videoPlayer.js",
-        "maxSize": "258kb"
+        "maxSize": "260kb"
       },
       {
         "path": "./lib/all.js",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "lodash": "^4.17.21",
     "srt-parser-2": "^1.2.3",
     "uuid": "^11.0.3",
-    "video.js": "^8.21.0",
+    "video.js": "^8.23.3",
     "videojs-contrib-ads": "^7.5.2",
     "videojs-contrib-dash": "^5.1.1",
     "videojs-ima": "^2.3.0",

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -381,7 +381,7 @@ $icon-font-path: '../icon-font' !default;
             font-weight: 400;
             font-style: normal;
 
-            content: '\f131';
+            content: '\f12d';
             display: block;
             position: absolute;
             width: 1em;


### PR DESCRIPTION
<img width="210" alt="image" src="https://github.com/user-attachments/assets/027a86e8-d67b-4f5b-b2df-70f15ba54f40" />
  

....
   
  
**This PR also bumps video.js version to latest (minor: 8.21.0 > 8.23.3)**