### PR TITLE
me-18006: test if video is playing on seek thumbnails page

### DIFF
--- a/docs/es-modules/seek-thumbs.html
+++ b/docs/es-modules/seek-thumbs.html
@@ -25,6 +25,7 @@
         crossorigin="anonymous"
         controls
         muted
+        autoplay
         playsinline
         data-cld-public-id="elephants"
       ></video>

--- a/test/e2e/specs/ESM/esmSeekThumbnailsPage.spec.ts
+++ b/test/e2e/specs/ESM/esmSeekThumbnailsPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testSeekThumbnailsPageVideoIsPlaying } from '../commonSpecs/seekThumbnailsPageVideoPlaying';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { ESM_URL } from '../../testData/esmUrl';
+
+const link = getEsmLinkByName(ExampleLinkName.SeekThumbnails);
+
+vpTest(`Test if video on ESM seek thumbnails page is playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testSeekThumbnailsPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/seekThumbnailsPage.spec.ts
+++ b/test/e2e/specs/NonESM/seekThumbnailsPage.spec.ts
@@ -1,17 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testSeekThumbnailsPageVideoIsPlaying } from '../commonSpecs/seekThumbnailsPageVideoPlaying';
 
 const link = getLinkByName(ExampleLinkName.SeekThumbnails);
 
 vpTest(`Test if video on seek thumbnails page is playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to seek thumbnails page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Validating that seek thumbnails video is playing', async () => {
-        await pomPages.seekThumbnailsPage.seekThumbnailsVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testSeekThumbnailsPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/seekThumbnailsPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/seekThumbnailsPageVideoPlaying.ts
@@ -1,0 +1,14 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testSeekThumbnailsPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to seek thumbnails page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that seek thumbnails video is playing', async () => {
+        await pomPages.seekThumbnailsPage.seekThumbnailsVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-18006
This test is navigating to ESM seek thumbnails page and make sure that video element is playing.
As it share common steps as `seekThumbnailsPage.spec.ts` that was already implemented I created common spec function `testSeekThumbnailsPageVideoIsPlaying` and using it on both specs.
Also added autoplay attribute to video element to be the same as the equivalent base example page