### PR TITLE
me-18007: test if video is playing on esm shoppable videos page

### DIFF
--- a/test/e2e/specs/ESM/esmShoppableVideosPage.spec.ts
+++ b/test/e2e/specs/ESM/esmShoppableVideosPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testShoppableVideosPageVideoIsPlaying } from '../commonSpecs/shoppableVideosPageVideoPlaying';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { ESM_URL } from '../../testData/esmUrl';
+
+const link = getEsmLinkByName(ExampleLinkName.ShoppableVideos);
+
+vpTest(`Test if video on ESM shoppable videos page is playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testShoppableVideosPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/shoppableVideosPage.spec.ts
+++ b/test/e2e/specs/NonESM/shoppableVideosPage.spec.ts
@@ -1,20 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testShoppableVideosPageVideoIsPlaying } from '../commonSpecs/shoppableVideosPageVideoPlaying';
 
 const link = getLinkByName(ExampleLinkName.ShoppableVideos);
 
 vpTest(`Test if video on shoppable videos page is playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to shoppable video page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Click on play button of shoppable videos to play video', async () => {
-        return pomPages.shoppableVideosPage.shoppableVideosVideoComponent.clickPlay();
-    });
-    await test.step('Validating that seek thumbnails video is playing', async () => {
-        await pomPages.shoppableVideosPage.shoppableVideosVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testShoppableVideosPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/shoppableVideosPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/shoppableVideosPageVideoPlaying.ts
@@ -1,0 +1,17 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testShoppableVideosPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to shoppable video page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Click on play button of shoppable videos to play video', async () => {
+        return pomPages.shoppableVideosPage.shoppableVideosVideoComponent.clickPlay();
+    });
+    await test.step('Validating that shoppable video is playing', async () => {
+        await pomPages.shoppableVideosPage.shoppableVideosVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-18007
This test is navigating to ESM shoppable videos page and make sure that video element is playing.
As it share common steps as `shoppableVideosPage.spec.ts` that was already implemented I created common spec function `testShoppableVideosPageVideoIsPlaying` and using it on both specs.