### PR TITLE
me-18008: test if video is playing on esm subtitles and captions page

### DIFF
--- a/docs/es-modules/subtitles-and-captions.html
+++ b/docs/es-modules/subtitles-and-captions.html
@@ -24,7 +24,6 @@
         playsinline
         controls
         muted
-        autoplay
         class="cld-video-player cld-fluid"
         crossorigin="anonymous"
         width="500"

--- a/test/e2e/specs/ESM/esmSubtitlesAndCaptionsPage.spec.ts
+++ b/test/e2e/specs/ESM/esmSubtitlesAndCaptionsPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testSubtitlesAndCaptionsPageVideoIsPlaying } from '../commonSpecs/subtitlesAndCaptionsPgaeVideoPlaying';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { ESM_URL } from '../../testData/esmUrl';
+
+const link = getEsmLinkByName(ExampleLinkName.SubtitlesAndCaptions);
+
+vpTest(`Test if 5 videos on ESM subtitles and captions page are playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testSubtitlesAndCaptionsPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/subtitlesAndCaptionsPage.spec.ts
+++ b/test/e2e/specs/NonESM/subtitlesAndCaptionsPage.spec.ts
@@ -1,44 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testSubtitlesAndCaptionsPageVideoIsPlaying } from '../commonSpecs/subtitlesAndCaptionsPgaeVideoPlaying';
 
 const link = getLinkByName(ExampleLinkName.SubtitlesAndCaptions);
 
 vpTest(`Test if 5 videos on subtitles and captions page are playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to subtitles and captions page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Click on play button of srt and vtt video to play video', async () => {
-        return pomPages.subtitlesAndCaptionsVideosPage.srtAndVttVideoComponent.clickPlay();
-    });
-    await test.step('Validating that srt and vtt video is playing', async () => {
-        await pomPages.subtitlesAndCaptionsVideosPage.srtAndVttVideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Click on play button of playlist subtitles video to play video', async () => {
-        return pomPages.subtitlesAndCaptionsVideosPage.playlistSubtitlesVideoComponent.clickPlay();
-    });
-    await test.step('Validating that playlist subtitles video is playing', async () => {
-        await pomPages.subtitlesAndCaptionsVideosPage.playlistSubtitlesVideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Click on play button of paced and styled captions video to play video', async () => {
-        return pomPages.subtitlesAndCaptionsVideosPage.pacedStyledVideoComponent.clickPlay();
-    });
-    await test.step('Validating that paced and styled captions video is playing', async () => {
-        await pomPages.subtitlesAndCaptionsVideosPage.pacedStyledVideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Click on play button of karaoke video to play video', async () => {
-        return pomPages.subtitlesAndCaptionsVideosPage.karaokeVideoComponent.clickPlay();
-    });
-    await test.step('Validating that karaoke video is playing', async () => {
-        await pomPages.subtitlesAndCaptionsVideosPage.karaokeVideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Click on play button of translated transcript video to play video', async () => {
-        return pomPages.subtitlesAndCaptionsVideosPage.translatedTranscriptVideoComponent.clickPlay();
-    });
-    await test.step('Validating that translated transcript video is playing', async () => {
-        await pomPages.subtitlesAndCaptionsVideosPage.translatedTranscriptVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testSubtitlesAndCaptionsPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/subtitlesAndCaptionsPgaeVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/subtitlesAndCaptionsPgaeVideoPlaying.ts
@@ -1,0 +1,41 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testSubtitlesAndCaptionsPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to subtitles and captions page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Click on play button of srt and vtt video to play video', async () => {
+        return pomPages.subtitlesAndCaptionsVideosPage.srtAndVttVideoComponent.clickPlay();
+    });
+    await test.step('Validating that srt and vtt video is playing', async () => {
+        await pomPages.subtitlesAndCaptionsVideosPage.srtAndVttVideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Click on play button of playlist subtitles video to play video', async () => {
+        return pomPages.subtitlesAndCaptionsVideosPage.playlistSubtitlesVideoComponent.clickPlay();
+    });
+    await test.step('Validating that playlist subtitles video is playing', async () => {
+        await pomPages.subtitlesAndCaptionsVideosPage.playlistSubtitlesVideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Click on play button of paced and styled captions video to play video', async () => {
+        return pomPages.subtitlesAndCaptionsVideosPage.pacedStyledVideoComponent.clickPlay();
+    });
+    await test.step('Validating that paced and styled captions video is playing', async () => {
+        await pomPages.subtitlesAndCaptionsVideosPage.pacedStyledVideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Click on play button of karaoke video to play video', async () => {
+        return pomPages.subtitlesAndCaptionsVideosPage.karaokeVideoComponent.clickPlay();
+    });
+    await test.step('Validating that karaoke video is playing', async () => {
+        await pomPages.subtitlesAndCaptionsVideosPage.karaokeVideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Click on play button of translated transcript video to play video', async () => {
+        return pomPages.subtitlesAndCaptionsVideosPage.translatedTranscriptVideoComponent.clickPlay();
+    });
+    await test.step('Validating that translated transcript video is playing', async () => {
+        await pomPages.subtitlesAndCaptionsVideosPage.translatedTranscriptVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-18008
This test is navigating to ESM subtitles and captions page and make sure that video elements are playing.
As it share common steps as `subtitlesAndCaptionsPage.spec.ts` that was already implemented I created common spec function `testSubtitlesAndCaptionsPageVideoIsPlaying` and using it on both specs.
Also I removed autoplay to first video to be the same as the equivalent base example page.