### PR TITLE
me-18009: test if video is playing on esm video transformations page

### DIFF
--- a/test/e2e/specs/ESM/esmVideoTransformationsPage.spec.ts
+++ b/test/e2e/specs/ESM/esmVideoTransformationsPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testVideoTransformationsPageVideoIsPlaying } from '../commonSpecs/videoTransformationsPage';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { ESM_URL } from '../../testData/esmUrl';
+
+const link = getEsmLinkByName(ExampleLinkName.VideoTransformations);
+
+vpTest(`Test if 3 videos on ESM video transformations page are playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testVideoTransformationsPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/videoTransformationsPage.spec.ts
+++ b/test/e2e/specs/NonESM/videoTransformationsPage.spec.ts
@@ -1,26 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testVideoTransformationsPageVideoIsPlaying } from '../commonSpecs/videoTransformationsPage';
 
 const link = getLinkByName(ExampleLinkName.VideoTransformations);
 
 vpTest(`Test if 3 videos on video transformations page are playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to video transformations page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Validating that via source transformation video is playing', async () => {
-        await pomPages.videoTransformationsPage.viaSourceVideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Validating that via player transformation video is playing', async () => {
-        await pomPages.videoTransformationsPage.viaPlayerVideoComponent.validateVideoIsPlaying(true);
-    });
-    await test.step('Scroll until data cld transformation video element is visible', async () => {
-        await pomPages.videoTransformationsPage.viaDataCldTransformationsVideoComponent.locator.scrollIntoViewIfNeeded();
-    });
-    await test.step('Validating that via data cld transformation video is playing', async () => {
-        await pomPages.videoTransformationsPage.viaDataCldTransformationsVideoComponent.validateVideoIsPlaying(true);
-    });
+    await testVideoTransformationsPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/videoTransformationsPage.ts
+++ b/test/e2e/specs/commonSpecs/videoTransformationsPage.ts
@@ -1,0 +1,23 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testVideoTransformationsPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to video transformations page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Validating that via source transformation video is playing', async () => {
+        await pomPages.videoTransformationsPage.viaSourceVideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Validating that via player transformation video is playing', async () => {
+        await pomPages.videoTransformationsPage.viaPlayerVideoComponent.validateVideoIsPlaying(true);
+    });
+    await test.step('Scroll until data cld transformation video element is visible', async () => {
+        await pomPages.videoTransformationsPage.viaDataCldTransformationsVideoComponent.locator.scrollIntoViewIfNeeded();
+    });
+    await test.step('Validating that via data cld transformation video is playing', async () => {
+        await pomPages.videoTransformationsPage.viaDataCldTransformationsVideoComponent.validateVideoIsPlaying(true);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-18009
This test is navigating to ESM video transformations page and make sure that video elements are playing.
As it share common steps as `videoTransformationsPage.spec.ts` that was already implemented I created common spec function `testVideoTransformationsPageVideoIsPlaying` and using it on both specs.