### PR TITLE
me-18010: test if videos are playing on esm vast and vpaid page

### DIFF
--- a/test/e2e/specs/ESM/esmVastAndVpaidPage.spec.ts
+++ b/test/e2e/specs/ESM/esmVastAndVpaidPage.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testVastAndVpaidPageVideoIsPlaying } from '../commonSpecs/vastAndVpaidPage';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { ESM_URL } from '../../testData/esmUrl';
+
+const link = getEsmLinkByName(ExampleLinkName.VASTAndVPAIDSupport);
+
+vpTest(`Test if 2 videos on ESM vast and vpaid page are playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testVastAndVpaidPageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/vastAndVpaidPage.spec.ts
+++ b/test/e2e/specs/NonESM/vastAndVpaidPage.spec.ts
@@ -1,24 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testVastAndVpaidPageVideoIsPlaying } from '../commonSpecs/vastAndVpaidPage';
 
 const link = getLinkByName(ExampleLinkName.VASTAndVPAIDSupport);
 
 vpTest(`Test if 2 videos on vast and vpaid page are playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to vast and vpaid page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Click on play button of single video with ads to play video', async () => {
-        return pomPages.vastAndVpaidPage.singleVideoWithAdsVideoComponent.clickPlay();
-    });
-    //Sending timeout of 12 seconds to wait until the ad finishes (10 sec) and the video will start
-    await test.step('Validating that single video with ads is playing', async () => {
-        await pomPages.vastAndVpaidPage.singleVideoWithAdsVideoComponent.validateVideoIsPlaying(true, 12000);
-    });
-    await test.step('Validating that playlist with ads video is playing', async () => {
-        await pomPages.vastAndVpaidPage.playlistWithAdsVideoComponent.validateVideoIsPlaying(true, 12000);
-    });
+    await testVastAndVpaidPageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/vastAndVpaidPage.ts
+++ b/test/e2e/specs/commonSpecs/vastAndVpaidPage.ts
@@ -1,0 +1,21 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testVastAndVpaidPageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to vast and vpaid page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Click on play button of single video with ads to play video', async () => {
+        return pomPages.vastAndVpaidPage.singleVideoWithAdsVideoComponent.clickPlay();
+    });
+    //Sending timeout of 12 seconds to wait until the ad finishes (10 sec) and the video will start
+    await test.step('Validating that single video with ads is playing', async () => {
+        await pomPages.vastAndVpaidPage.singleVideoWithAdsVideoComponent.validateVideoIsPlaying(true, 12000);
+    });
+    await test.step('Validating that playlist with ads video is playing', async () => {
+        await pomPages.vastAndVpaidPage.playlistWithAdsVideoComponent.validateVideoIsPlaying(true, 12000);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-18010
This test is navigating to ESM vast and vpaid page and make sure that video elements are playing.
As it share common steps as `vastAndVpaidPage.spec.ts` that was already implemented I created common spec function `testVastAndVpaidPageVideoIsPlaying` and using it on both specs.