### PR TITLE
me-18011: test if video is playing on esm vr 360 page

### DIFF
--- a/test/e2e/specs/ESM/esmVr360Page.spec.ts
+++ b/test/e2e/specs/ESM/esmVr360Page.spec.ts
@@ -1,0 +1,12 @@
+import { vpTest } from '../../fixtures/vpTest';
+import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testVr360PageVideoIsPlaying } from '../commonSpecs/vr360VideosPageVideoPlaying';
+import { getEsmLinkByName } from '../../testData/esmPageLinksData';
+import { ESM_URL } from '../../testData/esmUrl';
+
+const link = getEsmLinkByName(ExampleLinkName.VR360Videos);
+
+vpTest(`Test if video on ESM VR 360 videos page is playing as expected`, async ({ page, pomPages }) => {
+    await page.goto(ESM_URL);
+    await testVr360PageVideoIsPlaying(page, pomPages, link);
+});

--- a/test/e2e/specs/NonESM/vr360VideosPage.spec.ts
+++ b/test/e2e/specs/NonESM/vr360VideosPage.spec.ts
@@ -1,20 +1,10 @@
 import { vpTest } from '../../fixtures/vpTest';
-import { test } from '@playwright/test';
-import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
 import { getLinkByName } from '../../testData/pageLinksData';
 import { ExampleLinkName } from '../../testData/ExampleLinkNames';
+import { testVr360PageVideoIsPlaying } from '../commonSpecs/vr360VideosPageVideoPlaying';
 
 const link = getLinkByName(ExampleLinkName.VR360Videos);
 
 vpTest(`Test if video on VR 360 videos page is playing as expected`, async ({ page, pomPages }) => {
-    await test.step('Navigate to VR 360 videos page by clicking on link', async () => {
-        await pomPages.mainPage.clickLinkByName(link.name);
-        await waitForPageToLoadWithTimeout(page, 5000);
-    });
-    await test.step('Click on play button of 360 video play video', async () => {
-        return pomPages.vr360VideosPage.vr360VideoComponent.clickPlay();
-    });
-    await test.step('Validating that 360 video is playing', async () => {
-        await pomPages.vr360VideosPage.vr360VideoComponent.validateVideoIsPlaying(true, 6000);
-    });
+    await testVr360PageVideoIsPlaying(page, pomPages, link);
 });

--- a/test/e2e/specs/commonSpecs/vr360VideosPageVideoPlaying.ts
+++ b/test/e2e/specs/commonSpecs/vr360VideosPageVideoPlaying.ts
@@ -1,0 +1,17 @@
+import { Page, test } from '@playwright/test';
+import { waitForPageToLoadWithTimeout } from '../../src/helpers/waitForPageToLoadWithTimeout';
+import PageManager from '../../src/pom/PageManager';
+import { ExampleLinkType } from '../../types/exampleLinkType';
+
+export async function testVr360PageVideoIsPlaying(page: Page, pomPages: PageManager, link: ExampleLinkType) {
+    await test.step('Navigate to VR 360 videos page by clicking on link', async () => {
+        await pomPages.mainPage.clickLinkByName(link.name);
+        await waitForPageToLoadWithTimeout(page, 5000);
+    });
+    await test.step('Click on play button of 360 video play video', async () => {
+        return pomPages.vr360VideosPage.vr360VideoComponent.clickPlay();
+    });
+    await test.step('Validating that 360 video is playing', async () => {
+        await pomPages.vr360VideosPage.vr360VideoComponent.validateVideoIsPlaying(true, 6000);
+    });
+}


### PR DESCRIPTION
Relevant task - https://cloudinary.atlassian.net/browse/ME-18011
This test is navigating to ESM vr 360 page and make sure that video element is playing.
As it share common steps as `vastAndVpaidPage.spec.ts` that was already implemented I created common spec function `testVr360PageVideoIsPlaying `and using it on both specs.