### PR TITLE
fix: internal analytics

### DIFF
--- a/src/plugins/cloudinary/models/video-source/video-source.js
+++ b/src/plugins/cloudinary/models/video-source/video-source.js
@@ -153,7 +153,7 @@ class VideoSource extends BaseSource {
       const [type, codecTrans] = formatToMimeTypeAndTransformation(sourceType);
 
       // If user's transformation include video_codec then don't add another video codec to transformation
-      if (codecTrans && !(hasCodec(opts.transformation) || hasCodec(this.raw_transformation()))) {
+      if (codecTrans && !(hasCodec(opts.transformation) || hasCodec(this.rawTransformation()))) {
         opts.transformation = mergeTransformations(opts.transformation, codecTrans);
       }
 

--- a/src/video-player.const.js
+++ b/src/video-player.const.js
@@ -1,7 +1,6 @@
 // Parameters that can be passed to source configuration (inherited by source method)
 export const SOURCE_PARAMS = [
   'adaptiveStreaming',
-  'allowUsageReport',
   'autoShowRecommendations',
   'chapters',
   'cloudinaryConfig',
@@ -10,8 +9,7 @@ export const SOURCE_PARAMS = [
   'poster',
   'posterOptions',
   'publicId',
-  'queryParams',
-  'raw_transformation',
+  'rawTransformation',
   'recommendations',
   'shoppable',
   'source',
@@ -29,6 +27,7 @@ export const PLAYER_PARAMS = SOURCE_PARAMS.concat([
   '_internalAnalyticsMetadata',
   'ads',
   'aiHighlightsGraph',
+  'allowUsageReport',
   'analytics',
   'autoplayMode',
   'chaptersButton',
@@ -46,6 +45,7 @@ export const PLAYER_PARAMS = SOURCE_PARAMS.concat([
   'playedEventTimes',
   'playlistWidget',
   'qualitySelector',
+  'queryParams',
   'seekThumbnails',
   'showJumpControls'
 ]);


### PR DESCRIPTION
This fixes the broken internal analytics config, a regression introduced in v3.x
The fix is based on a line-by-line comparison I did with [the previous version](https://github.com/cloudinary/cloudinary-video-player/blob/v2.6.0/src/video-player.const.js)