### PR TITLE
fix(VIDEO-19832) - playlist and playlistByTag analytics

### DIFF
--- a/src/utils/get-analytics-player-options.js
+++ b/src/utils/get-analytics-player-options.js
@@ -73,7 +73,9 @@ const getAdsOptions = (adsOptions = {}) => ({
   adsAdsInPlaylist: adsOptions.adsInPlaylist
 });
 
-const getPlaylistWidgetOptions = (playlistWidgetOptions = {}) => ({
+const getPlaylistOptions = (playlistWidgetOptions = {}) => ({
+  playlist: playlistWidgetOptions.playlist,
+  playlistByTag: playlistWidgetOptions.playlistByTag,
   playlistWidgetDirection: playlistWidgetOptions.direction,
   playlistWidgetTotal: playlistWidgetOptions.total
 });
@@ -121,5 +123,5 @@ export const getAnalyticsFromPlayerOptions = (playerOptions) => filterDefaultsAn
   ...getCloudinaryOptions(playerOptions.cloudinary),
   ...getSourceOptions(playerOptions.sourceOptions),
   ...getAdsOptions(playerOptions.ads),
-  ...getPlaylistWidgetOptions(playerOptions.playlistWidget)
+  ...getPlaylistOptions(playerOptions.playlistWidget)
 });

--- a/src/video-player.js
+++ b/src/video-player.js
@@ -603,6 +603,8 @@ class VideoPlayer extends Utils.mixin(Eventable) {
   }
 
   playlist(sources, options = {}) {
+    this.playerOptions.playlistWidget = { ...(this.playerOptions.playlistWidget || {}), playlist: true };
+
     options = Object.assign({}, options, { playlistWidget: this.playerOptions.playlistWidget });
 
     this.videojs.one(PLAYER_EVENT.READY, async () => {
@@ -614,6 +616,8 @@ class VideoPlayer extends Utils.mixin(Eventable) {
   }
 
   playlistByTag(tag, options = {}) {
+    this.playerOptions.playlistWidget = { ...(this.playerOptions.playlistWidget || {}), playlistByTag: true };
+
     options = Object.assign({}, options, { playlistWidget: this.playerOptions.playlistWidget });
 
     return new Promise((resolve) => {


### PR DESCRIPTION
Adding an indication of `playlist` or `playlistByTag` usage to our analytics call