### PR TITLE
fix(VIDEO-19824): errors for missing source-maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "lib",
     "types",
     "LICENSE",
-    "README.md",
-    "!**/*.map"
+    "README.md"
   ],
   "exports": {
     ".": {

--- a/webpack/common.config.js
+++ b/webpack/common.config.js
@@ -41,8 +41,6 @@ const webpackConfig = {
     }
   },
 
-  devtool: 'source-map',
-
   resolve: {
     extensions: ['.js', '.scss'],
     modules: [path.resolve(__dirname, '../src'), 'node_modules'],

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -11,6 +11,7 @@ const VERSION = JSON.stringify(process.env.npm_package_version);
 
 module.exports = merge(webpackCommon, {
   mode: 'development',
+  devtool: 'source-map',
 
   plugins: [
     new BannerPlugin({


### PR DESCRIPTION
This PR fixes an issue caused by the fact we're not publishing source-maps files to npm.