### PR TITLE
fix(VIDEO-20021): subtitles defined in HLS manifest

### DIFF
--- a/src/plugins/adaptive-streaming/videojs-contrib-hlsjs.js
+++ b/src/plugins/adaptive-streaming/videojs-contrib-hlsjs.js
@@ -105,8 +105,13 @@ function Html5HlsJS(source, tech) {
   // if native text tracks are not supported on this browser.
   if (!tech.featuresNativeTextTracks) {
     Object.defineProperty(el, 'textTracks', {
-      value: tech.textTracks,
-      writable: false
+      get: function() {
+        try {
+          return typeof tech.textTracks === 'function' ? tech.textTracks() : tech.textTracks;
+        } catch {
+          return [];
+        }
+      }
     });
     el.addTextTrack = function() {
       return tech.addTextTrack.apply(tech, arguments);


### PR DESCRIPTION
The new HLS engine was having issues with text-tracks defined via HLS manifest