### PR TITLE
fix: hide poster image on error

### DIFF
--- a/src/plugins/cloudinary/index.js
+++ b/src/plugins/cloudinary/index.js
@@ -292,6 +292,8 @@ class CloudinaryContext {
         this.disablePoster(posterOptions.posterColor);
       } else if (src.poster()) {
         this.player.poster(src.poster().url());
+        const posterImg = this.player.posterImage.el().querySelector('img');
+        posterImg?.addEventListener('error', () => this.disablePoster(), { once: true });
       }
 
       _sources = src.generateSources().reduce((srcs, src) => {


### PR DESCRIPTION
This will hide the poster image if it's missing or broken