### PR TITLE
fix: [VIDEO-20833] track lazy bundle analytics

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,17 @@ import { createAsyncPlayer, createMultiplePlayers, createMultipleSync, setupClou
 import { createDeferredPlayer } from './utils/deferred-player';
 
 const importCore = () => import(/* webpackChunkName: "cld-player-core" */ './video-player.js');
+const mergeOpts = (...opts) => Object.assign({}, ...opts, {
+  _internalAnalyticsMetadata: Object.assign(
+    {},
+    ...opts.map((opt) => opt?._internalAnalyticsMetadata || {}),
+    { playerBundle: 'lazy' }
+  )
+});
 
 export const videoPlayer = (id, playerOptions = {}, ready) =>
   createDeferredPlayer(
-    importCore().then((m) => m.createVideoPlayer(id, playerOptions, ready))
+    importCore().then((m) => m.createVideoPlayer(id, mergeOpts(playerOptions), ready))
   );
 
 export const videoPlayers = (selector, playerOptions, ready) =>
@@ -15,7 +22,7 @@ export const videoPlayers = (selector, playerOptions, ready) =>
 export const player = (id, playerOptions = {}, ready) =>
   createAsyncPlayer(id, playerOptions, ready, async (videoElement, opts, r) => {
     const { createPlayerWithConfig } = await importCore();
-    return createPlayerWithConfig(videoElement, opts, r);
+    return createPlayerWithConfig(videoElement, mergeOpts(opts), r);
   });
 
 export const players = (selector, playerOptions, ready) =>
@@ -25,14 +32,13 @@ const cloudinaryVideoPlayerLegacyConfig = (instanceConfig = {}) => {
   console.warn(
     'Cloudinary.new() is deprecated and will be removed. Please use cloudinary.videoPlayer() instead.'
   );
-  const mergeOpts = (callOpts = {}) => Object.assign({}, instanceConfig, callOpts);
   return {
     videoPlayer: (id, playerOptions = {}, ready) =>
       createDeferredPlayer(
-        importCore().then((m) => m.createVideoPlayer(id, mergeOpts(playerOptions), ready))
+        importCore().then((m) => m.createVideoPlayer(id, mergeOpts(instanceConfig, playerOptions), ready))
       ),
     videoPlayers: (selector, playerOptions = {}, ready) =>
-      createMultipleSync(selector, mergeOpts(playerOptions), ready, videoPlayer)
+      createMultipleSync(selector, mergeOpts(instanceConfig, playerOptions), ready, videoPlayer)
   };
 };
 


### PR DESCRIPTION
## Summary

Lazy entry paths (`videoPlayer`, `player`, and legacy `Cloudinary.new()` wrappers) now merge `_internalAnalyticsMetadata` with `playerBundle: 'lazy'` so internal analytics can tell lazy-loaded core apart from eager bundles.

## Changes

- Introduce a shared `mergeOpts` helper that shallow-merges option objects and merges `_internalAnalyticsMetadata` from each layer, then sets `playerBundle` to `'lazy'`.
- Pass merged options into deferred `createVideoPlayer` and async `createPlayerWithConfig` flows.
- Legacy `cloudinaryVideoPlayerLegacyConfig` uses the same helper so instance config and per-call options merge consistently (instance + call) while still tagging lazy analytics.
