### PR TITLE
fix: support f_auto extensionless raw URLs

### DIFF
--- a/src/plugins/cloudinary/models/video-source/video-source.const.js
+++ b/src/plugins/cloudinary/models/video-source/video-source.const.js
@@ -13,7 +13,7 @@ export const DEFAULT_VIDEO_PARAMS = {
   chapters: {}
 };
 
-const COMMON_VIDEO_EXTENSIONS = [
+export const COMMON_VIDEO_EXTENSIONS = [
   '3g2',
   '3gp',
   'avi',

--- a/src/plugins/cloudinary/models/video-source/video-source.js
+++ b/src/plugins/cloudinary/models/video-source/video-source.js
@@ -7,6 +7,7 @@ import {
   ADAPTIVE_SOURCETYPES,
   DEFAULT_POSTER_PARAMS,
   DEFAULT_VIDEO_PARAMS,
+  COMMON_VIDEO_EXTENSIONS,
   VIDEO_SUFFIX_REMOVAL_PATTERN
 } from './video-source.const';
 import {
@@ -167,8 +168,7 @@ class VideoSource extends BaseSource {
 
   generateSources() {
     if (this.isRawUrl) {
-      const type = this.sourceTypes()[0] === 'auto' ? null : this.sourceTypes()[0];
-      return [this.generateRawSource(this.publicId(), type)];
+      return [this.generateRawSource(this.publicId(), this.sourceTypes()[0])];
     }
 
     const srcs = this.sourceTypes().map(sourceType => {
@@ -231,17 +231,21 @@ class VideoSource extends BaseSource {
   }
 
   generateRawSource(url, type) {
-    type = type || url.split('.').pop();
+    // If type is not provided (default is 'auto'), determine it from the URL extension
+    if (!type || type === 'auto') {
+      const ext = url.split('.').pop().split(/[?#]/)[0].toLowerCase();
+      type = COMMON_VIDEO_EXTENSIONS.includes(ext) ? ext : 'auto';
+    }
 
     const isAdaptive = ADAPTIVE_SOURCETYPES.includes(type);
 
-    if (CONTAINER_MIME_TYPES[type]) {
-      type = CONTAINER_MIME_TYPES[type];
-    } else {
-      type = type ? `video/${type}` : null;
-    }
-
-    return { type, src: url, cldSrc: this, isAdaptive, withCredentials: this.withCredentials };
+    return { 
+      type: CONTAINER_MIME_TYPES[type] || `video/${type}`, 
+      src: url, 
+      cldSrc: this, 
+      isAdaptive, 
+      withCredentials: this.withCredentials 
+    };
   }
 
   info(value) {


### PR DESCRIPTION
## Summary
Raw URLs without a file extension (e.g. Cloudinary `f_auto` delivery URLs like `https://res.cloudinary.com/.../cld-sample-video`) could not be played because `generateRawSource` was falling back to `url.split('.').pop()`, which returns a bogus "extension" (the full last URL path segment), producing an invalid MIME type like `video/com/.../cld-sample-video`.

The fix routes extensionless raw URLs through the existing `video/auto` middleware, which issues a HEAD request to resolve the real `Content-Type` from the server.

## Changes
- `generateRawSource` now checks the URL's last segment against `COMMON_VIDEO_EXTENSIONS`
  - Known extension (e.g. `.mp4`, `.m3u8`) - used directly as before
  - Unknown/no extension - falls back to `'auto'` - `video/auto` MIME type, triggering the HEAD middleware
- Explicit `sourceTypes` (non-`auto`) are still respected and passed through unchanged
- `COMMON_VIDEO_EXTENSIONS` exported from `video-source.const.js` to enable the check
- `generateSources` simplified: no longer converts `'auto'` to `null` before passing to `generateRawSource`

## How to Test
Load the player with an extensionless `f_auto` Cloudinary URL:
```js
player.source('https://res.cloudinary.com/<cloud>/video/upload/c_scale,h_720,w_640/samples/cld-sample-video');
```
Expected: video plays normally (middleware resolves `video/mp4` via HEAD request).

Also verify a raw URL with a known extension still works:
```js
player.source('https://example.com/video.mp4');
```
Expected: plays as `video/mp4` directly, no HEAD request needed.
