### PR TITLE
fix(ui): show full playback rate values in the rates menu

### DIFF
--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -384,9 +384,22 @@ $icon-font-path: '../icon-font' !default;
     }
   }
 
-  .vjs-playback-rate-value {
-    font-size: 1.3em;
-    line-height: 2.3em;
+  .vjs-playback-rate {
+    // Fit three-digit rates (e.g. 1.75) at the value's 1.3em font-size.
+    width: 3em;
+
+    .vjs-playback-rate-value {
+      font-size: 1.3em;
+      line-height: 2.3em;
+    }
+
+    // video.js caps this menu at 4em, which truncates rates like 1.75 once the
+    // item padding and the selected-item gutter are subtracted. The content is
+    // absolutely positioned, so it - not the menu - has to grow.
+    .vjs-menu .vjs-menu-content {
+      width: max-content;
+      min-width: 100%;
+    }
   }
 
   .vjs-subs-caps-button {


### PR DESCRIPTION
video.js caps the playback rate menu at a fixed 4em. Once the menu item padding and the selected-item checkmark gutter are subtracted, rates like 1.75x no longer fit and get ellipsized to "1...".

The menu content is absolutely positioned, so it - not the menu box - is the element that has to grow: size it to max-content, with min-width 100% so short rate lists keep the original popup width. Also widen the control itself to 3em, since the 1.75x label measures 36.1px against the stock 2.5em (36px) button and crowds the neighbouring control.