### PR TITLE
feat(config): default preload to metadata

### DIFF
--- a/src/config/configSchema.json
+++ b/src/config/configSchema.json
@@ -66,7 +66,7 @@
     "preload": {
       "type": "string",
       "enum": ["auto", "metadata", "none"],
-      "default": "auto"
+      "default": "metadata"
     },
     "sourceTransformation": {
       "type": "object",

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -15,7 +15,7 @@ export default {
   aiHighlightsGraph: false,
   visualSearch: false,
   download: false,
-  preload: PRELOAD.AUTO,
+  preload: PRELOAD.METADATA,
   textTrackSettings: false,
   loop: false,
   muted: false,


### PR DESCRIPTION
Align the player default with standard browser behavior and cut the initial network cost: `auto` lets the browser pull media data for a video the user may never play, while `metadata` fetches only what is needed to report duration and dimensions.

Updated in both places the default is declared - defaults.js (runtime) and configSchema.json, which is copied into the published bundles as the documented option reference.

Note this governs the native <video> element, so it applies to progressive sources; hls.js drives its own loading for adaptive streaming, and autoplay still fetches media data either way.