### PR TITLE
fix(ci): pin cpina/github-action-push-to-another-repository to a commit SHA

### DIFF
--- a/.github/workflows/e2e_pr.yml
+++ b/.github/workflows/e2e_pr.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Pushes to reports repository
         if: always()
-        uses: cpina/github-action-push-to-another-repository@main
+        uses: cpina/github-action-push-to-another-repository@55306faa4ed53b815ae49e564af8cfb359d32ae2 # main as of 2025-09-25
         env:
           API_TOKEN_GITHUB: ${{ secrets.BOT_TOKEN }}
         with:


### PR DESCRIPTION
## What

Pins `cpina/github-action-push-to-another-repository` from `@main` to commit `55306faa4ed53b815ae49e564af8cfb359d32ae2` (which is what `main` points at as of 2025-09-25).

One line. No behaviour change.

## Why this one specifically

`@main` is a mutable branch. Whoever controls that upstream repository decides what runs in this repository's CI, and can change it at any time without any signal here.

The step it runs in has `secrets.BOT_TOKEN` in scope:

```yaml
- name: Pushes to reports repository
  uses: cpina/github-action-push-to-another-repository@main
  env:
    API_TOKEN_GITHUB: ${{ secrets.BOT_TOKEN }}
```

`e2e_pr.yml` runs on `pull_request`, so this executes on ordinary development activity.

**What makes this different from the usual "pin your actions" advice:** every other protection on this repository gates a *person*. Master requires a code-owner approval. External contributor workflow runs require approval (`approval_policy: all_external_contributors`). Force pushes are blocked. None of that applies here — an upstream compromise needs no pull request, no review, and no run approval. It arrives on the next push to any branch.

`rtCamp/action-slack-notify@v2.2.0` in `release.yml` is the same class but lower risk: a tag rather than a branch, so it moves only if the maintainer retags. Worth pinning too — left out of this PR to keep it to one line and avoid a conflict with #1075, which already touches `release.yml`.

## Verification

- `e2e_pr.yml` parses as valid YAML
- the pinned SHA resolves to the current head of `main` in the upstream repository, so the action code being run is byte-identical to what runs today

🤖 Generated with [Claude Code](https://claude.com/claude-code)
