### PR TITLE
feat(docs): interactive ads playground demo page

### DIFF
--- a/docs/ads-playground.html
+++ b/docs/ads-playground.html
@@ -625,7 +625,8 @@
       // ---- snippet -----------------------------------------------------------------------
       function renderSnippet(s) {
         var lines = [];
-        lines.push("const player = await cloudinary.player('player', {");
+        var needsPlayerRef = s.mode === 'playlist';
+        lines.push((needsPlayerRef ? 'const player = ' : '') + "await cloudinary.player('player', {");
         lines.push("  cloudName: '" + s.cloudName + "',");
         if (s.mode !== 'playlist') {
           lines.push("  publicId: '" + s.publicId.replace(/'/g, "\\'") + "',");

--- a/docs/ads-playground.html
+++ b/docs/ads-playground.html
@@ -625,15 +625,16 @@
       // ---- snippet -----------------------------------------------------------------------
       function renderSnippet(s) {
         var lines = [];
-        lines.push("const player = cloudinary.videoPlayer('player', {");
+        lines.push("const player = await cloudinary.player('player', {");
         lines.push("  cloudName: '" + s.cloudName + "',");
+        if (s.mode !== 'playlist') {
+          lines.push("  publicId: '" + s.publicId.replace(/'/g, "\\'") + "',");
+        }
         lines.push('  ads: ' + JSON.stringify(adsOptions(s), null, 2).replace(/\n/g, '\n  ').replace(/"([^"]+)":/g, '$1:').replace(/"/g, "'"));
         lines.push('});');
-        lines.push('');
         if (s.mode === 'playlist') {
+          lines.push('');
           lines.push("player.playlistByTag('" + s.playlistTag + "', { autoAdvance: true, repeat: true });");
-        } else {
-          lines.push("player.source('" + s.publicId.replace(/'/g, "\\'") + "');");
         }
         $('snippet').textContent = lines.join('\n');
       }

--- a/docs/ads-playground.html
+++ b/docs/ads-playground.html
@@ -626,7 +626,7 @@
       function renderSnippet(s) {
         var lines = [];
         var needsPlayerRef = s.mode === 'playlist';
-        lines.push((needsPlayerRef ? 'const player = ' : '') + "await cloudinary.player('player', {");
+        lines.push((needsPlayerRef ? 'const player = await ' : '') + "cloudinary.player('player', {");
         lines.push("  cloudName: '" + s.cloudName + "',");
         if (s.mode !== 'playlist') {
           lines.push("  publicId: '" + s.publicId.replace(/'/g, "\\'") + "',");

--- a/docs/ads-playground.html
+++ b/docs/ads-playground.html
@@ -1,0 +1,820 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ads Playground · Cloudinary Video Player</title>
+  <link href="https://res.cloudinary.com/cloudinary-marketing/image/upload/f_auto,q_auto/c_scale,w_32/v1597183771/creative_staging/cloudinary_internal/Website/Brand%20Updates/Favicon/cloudinary_web_favicon_192x192.png" rel="icon" type="image/png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+
+  <script type="text/javascript" src="./scripts.js?full"></script>
+  <script src="https://imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
+
+  <style>
+    :root {
+      --bg: #070F1A;
+      --bg2: #0B1623;
+      --bg3: #162436;
+      --text: #ffffff;
+      --dim: rgba(255, 255, 255, 0.58);
+      --faint: rgba(255, 255, 255, 0.30);
+      --line: rgba(255, 255, 255, 0.09);
+      --accent: #0095FF;
+      --accent-hover: #33AAFF;
+      --accent-active: #007FDB;
+      --danger: #FE5981;
+      --radius-card: 16px;
+      --radius-small: 8px;
+      --radius-input: 6px;
+      --radius-btn: 32px;
+      --radius-badge: 4px;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: Inter, -apple-system, "Segoe UI", system-ui, sans-serif;
+      font-size: 14px;
+      line-height: 1.5;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .page {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 24px 64px;
+    }
+
+    /* ---------- hero ---------- */
+    .hero {
+      background: linear-gradient(170deg, #162436 40%, #2A3E58 90%);
+      margin: 0 0 32px;
+    }
+    .hero-inner {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 40px 24px 36px;
+    }
+    .breadcrumb {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--accent);
+      margin: 0 0 8px;
+    }
+    .breadcrumb span { color: var(--dim); }
+    .hero h1 {
+      margin: 0 0 4px;
+      font-size: clamp(28px, 5vw, 44px);
+      font-weight: 800;
+      letter-spacing: -0.02em;
+    }
+    .hero p {
+      margin: 0;
+      color: var(--dim);
+      font-size: 16px;
+      max-width: 60ch;
+    }
+
+    /* ---------- layout ---------- */
+    .layout {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 360px;
+      gap: 24px;
+      align-items: start;
+    }
+    @media (max-width: 900px) {
+      .layout { grid-template-columns: 1fr; }
+    }
+
+    .card {
+      background: var(--bg2);
+      border: 1px solid var(--line);
+      border-radius: var(--radius-card);
+      padding: 20px;
+    }
+
+    /* ---------- player ---------- */
+    .player-card { padding: 12px; }
+    .player-frame {
+      border-radius: var(--radius-small);
+      overflow: hidden;
+      background: #000;
+      aspect-ratio: 16 / 9;
+    }
+    .player-frame .cld-video-player,
+    .player-frame video { width: 100%; height: 100%; }
+
+    .player-meta {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 12px 8px 4px;
+      min-height: 40px;
+    }
+    .now-playing {
+      color: var(--dim);
+      font-size: 13px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .badge {
+      display: none;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      padding: 3px 10px;
+      border-radius: var(--radius-badge);
+    }
+    .badge.on { display: inline-block; }
+    .badge-ad { background: var(--accent); color: #fff; }
+
+    /* ---------- event log ---------- */
+    .log-card { margin-top: 24px; padding: 0; overflow: hidden; }
+    .log-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px 20px;
+      border-bottom: 1px solid var(--line);
+    }
+    .log-head h2 { margin: 0; font-size: 14px; font-weight: 600; }
+    .log-body {
+      height: 200px;
+      overflow-y: auto;
+      padding: 12px 20px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 12px;
+      line-height: 1.7;
+    }
+    .log-empty { color: var(--dim); font-family: Inter, sans-serif; }
+    .log-line { color: var(--dim); }
+    .log-line .t { color: var(--dim); margin-right: 10px; }
+    .log-line.is-ad { color: var(--accent); }
+    .log-line.is-error { color: var(--danger); }
+
+    /* ---------- controls ---------- */
+    .controls { display: flex; flex-direction: column; gap: 24px; }
+
+    .group h2 {
+      margin: 0 0 12px;
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--dim);
+    }
+
+    .field { margin-bottom: 12px; }
+    .field:last-child { margin-bottom: 0; }
+    .field > label {
+      display: block;
+      font-size: 13px;
+      color: var(--dim);
+      margin-bottom: 6px;
+    }
+
+    input[type="text"], select {
+      width: 100%;
+      background: var(--bg);
+      border: 1px solid var(--line);
+      border-radius: var(--radius-input);
+      color: var(--text);
+      font: inherit;
+      font-size: 13px;
+      padding: 9px 12px;
+    }
+    input[type="text"]::placeholder { color: var(--faint); }
+    input[type="text"]:focus-visible, select:focus-visible,
+    button:focus-visible, .thumb:focus-visible, .seg label:focus-within {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+    select {
+      appearance: none;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='rgba(255,255,255,.5)' fill='none' stroke-width='1.5'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: right 12px center;
+      padding-right: 32px;
+    }
+
+    .row2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+
+    /* thumbnails */
+    .thumbs { display: flex; gap: 8px; flex-wrap: wrap; }
+    .thumb {
+      width: 88px;
+      height: 50px;
+      padding: 0;
+      border: 2px solid transparent;
+      border-radius: var(--radius-small);
+      overflow: hidden;
+      cursor: pointer;
+      background: var(--bg3);
+      flex-shrink: 0;
+    }
+    .thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
+    .thumb[aria-pressed="true"] { border-color: var(--accent); }
+    .thumb:hover { border-color: var(--faint); }
+    .thumb[aria-pressed="true"]:hover { border-color: var(--accent); }
+
+    /* segmented control */
+    .seg {
+      display: flex;
+      background: var(--bg);
+      border: 1px solid var(--line);
+      border-radius: var(--radius-input);
+      padding: 3px;
+      gap: 3px;
+    }
+    .seg label {
+      flex: 1;
+      text-align: center;
+      font-size: 13px;
+      color: var(--dim);
+      padding: 6px 4px;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    .seg input { position: absolute; opacity: 0; pointer-events: none; }
+    .seg input:checked + span { color: var(--text); }
+    .seg label:has(input:checked) { background: var(--bg3); color: var(--text); }
+
+    /* toggle switch */
+    .switch-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 8px 0;
+    }
+    .switch-row > span { font-size: 13px; color: var(--dim); }
+    .switch {
+      position: relative;
+      width: 36px;
+      height: 20px;
+      flex-shrink: 0;
+    }
+    .switch input { position: absolute; opacity: 0; width: 100%; height: 100%; margin: 0; cursor: pointer; }
+    .switch .track {
+      position: absolute;
+      inset: 0;
+      background: var(--bg3);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      transition: background 0.15s ease;
+      pointer-events: none;
+    }
+    .switch .track::after {
+      content: "";
+      position: absolute;
+      top: 2px; left: 2px;
+      width: 14px; height: 14px;
+      border-radius: 50%;
+      background: var(--dim);
+      transition: transform 0.15s ease, background 0.15s ease;
+    }
+    .switch input:checked ~ .track { background: var(--accent); border-color: var(--accent); }
+    .switch input:checked ~ .track::after { transform: translateX(16px); background: #fff; }
+    .switch input:focus-visible ~ .track { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+    /* buttons */
+    .btn {
+      font: inherit;
+      font-size: 14px;
+      font-weight: 600;
+      border: 0;
+      border-radius: var(--radius-btn);
+      padding: 10px 22px;
+      cursor: pointer;
+    }
+    .btn-primary { background: var(--accent); color: #fff; width: 100%; }
+    .btn-primary:hover { background: var(--accent-hover); }
+    .btn-primary:active { background: var(--accent-active); }
+    .btn-ghost {
+      background: transparent;
+      color: var(--dim);
+      border: 1px solid var(--line);
+      font-size: 13px;
+      padding: 7px 16px;
+    }
+    .btn-ghost:hover { color: var(--text); border-color: var(--faint); }
+
+    .actions { display: flex; flex-direction: column; gap: 10px; }
+    .actions .split { display: flex; gap: 10px; }
+    .actions .split .btn { flex: 1; }
+
+    /* snippet */
+    .snippet-card { margin-top: 24px; padding: 0; overflow: hidden; }
+    .snippet-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px 20px;
+      border-bottom: 1px solid var(--line);
+    }
+    .snippet-head h2 { margin: 0; font-size: 14px; font-weight: 600; }
+    pre.snippet {
+      margin: 0;
+      padding: 16px 20px;
+      overflow-x: auto;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 12px;
+      line-height: 1.7;
+      color: var(--dim);
+    }
+
+    .notice {
+      display: none;
+      background: rgba(254, 89, 129, 0.1);
+      border: 1px solid rgba(254, 89, 129, 0.35);
+      border-radius: var(--radius-small);
+      color: var(--danger);
+      font-size: 13px;
+      padding: 10px 14px;
+      margin-bottom: 16px;
+    }
+    .notice.on { display: block; }
+
+    .toast {
+      position: fixed;
+      bottom: 24px;
+      left: 50%;
+      transform: translate(-50%, 8px);
+      background: var(--bg3);
+      border: 1px solid var(--line);
+      border-radius: var(--radius-btn);
+      padding: 8px 18px;
+      font-size: 13px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.2s ease, transform 0.2s ease;
+    }
+    .toast.on { opacity: 1; transform: translate(-50%, 0); }
+
+    @media (prefers-reduced-motion: reduce) {
+      * { transition: none !important; }
+    }
+  </style>
+</head>
+<body>
+
+  <header class="hero">
+    <div class="hero-inner">
+      <p class="breadcrumb">Video Player <span>/ Ads Playground</span></p>
+      <h1>Ads Playground</h1>
+      <p>Demo client-side ad insertion with any source, ad tag and configuration — then copy the exact player setup.</p>
+    </div>
+  </header>
+
+  <main class="page">
+    <div class="notice" id="notice" role="alert"></div>
+
+    <div class="layout">
+
+      <section aria-label="Player and events">
+        <div class="card player-card">
+          <div class="player-frame" id="player-frame">
+            <video id="player" playsinline controls muted class="cld-video-player"></video>
+          </div>
+          <div class="player-meta">
+            <span class="now-playing" id="now-playing"></span>
+            <span class="badge badge-ad" id="ad-badge">Ad playing</span>
+          </div>
+        </div>
+
+        <div class="card log-card">
+          <div class="log-head">
+            <h2>Event log</h2>
+            <button type="button" class="btn btn-ghost" id="clear-log">Clear</button>
+          </div>
+          <div class="log-body" id="log" aria-live="polite" aria-label="Ad event log">
+            <p class="log-empty">Ad and player events will appear here.</p>
+          </div>
+        </div>
+
+        <div class="card snippet-card">
+          <div class="snippet-head">
+            <h2>Player config</h2>
+            <button type="button" class="btn btn-ghost" id="copy-snippet">Copy</button>
+          </div>
+          <pre class="snippet" id="snippet"></pre>
+        </div>
+      </section>
+
+      <form class="card controls" id="controls" aria-label="Playground settings">
+
+        <div class="group">
+          <h2>Source</h2>
+          <div class="field">
+            <div class="seg" role="radiogroup" aria-label="Source mode">
+              <label><input type="radio" name="mode" value="single" checked><span>Single video</span></label>
+              <label><input type="radio" name="mode" value="playlist"><span>Playlist</span></label>
+            </div>
+          </div>
+          <div class="field" id="thumbs-field">
+            <label id="thumbs-label">Sample videos</label>
+            <div class="thumbs" role="group" aria-labelledby="thumbs-label" id="thumbs"></div>
+          </div>
+          <div class="field" id="publicid-field">
+            <label for="publicId">Public ID or video URL</label>
+            <input type="text" id="publicId" value="elephants" autocomplete="off" spellcheck="false">
+          </div>
+          <div class="field" id="playlisttag-field" hidden>
+            <label for="playlistTag">Playlist tag</label>
+            <input type="text" id="playlistTag" value="video_race" autocomplete="off" spellcheck="false">
+          </div>
+          <div class="field">
+            <label for="cloudName">Cloud name</label>
+            <input type="text" id="cloudName" value="demo" autocomplete="off" spellcheck="false">
+          </div>
+        </div>
+
+        <div class="group">
+          <h2>Ad scenario</h2>
+          <div class="field">
+            <label for="preset">Preset</label>
+            <select id="preset"></select>
+          </div>
+          <div class="field">
+            <label for="adTagUrl">Ad tag URL</label>
+            <input type="text" id="adTagUrl" autocomplete="off" spellcheck="false" placeholder="Paste a VAST/VMAP tag URL">
+          </div>
+        </div>
+
+        <div class="group">
+          <h2>Options</h2>
+          <div class="row2 field">
+            <div>
+              <label for="adLabel">Ad label</label>
+              <input type="text" id="adLabel" value="Advertisement" autocomplete="off">
+            </div>
+            <div>
+              <label for="locale">Locale</label>
+              <select id="locale">
+                <option value="en" selected>English (en)</option>
+                <option value="fr">French (fr)</option>
+                <option value="de">German (de)</option>
+                <option value="es">Spanish (es)</option>
+                <option value="ja">Japanese (ja)</option>
+                <option value="he">Hebrew (he)</option>
+              </select>
+            </div>
+          </div>
+          <div class="row2 field">
+            <div>
+              <label for="prerollTimeout">Pre-roll timeout (ms)</label>
+              <input type="text" id="prerollTimeout" value="5000" inputmode="numeric" autocomplete="off">
+            </div>
+            <div>
+              <label for="postrollTimeout">Post-roll timeout (ms)</label>
+              <input type="text" id="postrollTimeout" value="5000" inputmode="numeric" autocomplete="off">
+            </div>
+          </div>
+          <div class="field" id="adsinplaylist-field" hidden>
+            <label>Ads in playlist</label>
+            <div class="seg" role="radiogroup" aria-label="Ads in playlist">
+              <label><input type="radio" name="adsInPlaylist" value="first-video" checked><span>First video</span></label>
+              <label><input type="radio" name="adsInPlaylist" value="every-video"><span>Every video</span></label>
+            </div>
+          </div>
+          <label class="switch-row">
+            <span>Show countdown</span>
+            <span class="switch"><input type="checkbox" id="showCountdown" checked><span class="track"></span></span>
+          </label>
+          <label class="switch-row">
+            <span>Debug logging (console)</span>
+            <span class="switch"><input type="checkbox" id="debug"><span class="track"></span></span>
+          </label>
+        </div>
+
+        <div class="actions">
+          <button type="submit" class="btn btn-primary" id="apply">Apply &amp; reload player</button>
+          <div class="split">
+            <button type="button" class="btn btn-ghost" id="share">Copy share link</button>
+            <button type="button" class="btn btn-ghost" id="reset">Reset</button>
+          </div>
+        </div>
+
+      </form>
+    </div>
+  </main>
+
+  <div class="toast" id="toast" role="status"></div>
+
+  <script>
+    (function () {
+      'use strict';
+
+      // ---- Google IMA public sample tags -------------------------------------------------
+      var GAMPAD = 'https://pubads.g.doubleclick.net/gampad/ads?';
+      var SINGLE = 'iu=/21775744923/external/single_ad_samples&sz=640x480&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=&cust_params=';
+      var VMAP = 'iu=/21775744923/external/vmap_ad_samples&sz=640x480&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&correlator=&cust_params=';
+
+      var PRESETS = [
+        { key: 'preroll', label: 'Pre-roll (linear)', url: GAMPAD + SINGLE + 'sample_ct%3Dlinear' },
+        { key: 'preonly-vmap', label: 'Pre-roll only (VMAP)', url: GAMPAD + 'sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpreonly&cmsid=496&vid=short_onecue&correlator=' },
+        { key: 'premidpost', label: 'Pre + mid + post-roll (VMAP)', url: GAMPAD + VMAP + 'sample_ar%3Dpremidpost' },
+        { key: 'pods', label: 'Ad pods (VMAP)', url: GAMPAD + VMAP + 'sample_ar%3Dpremidpostpod' },
+        { key: 'postonly', label: 'Post-roll only (VMAP)', url: GAMPAD + VMAP + 'sample_ar%3Dpostonly' },
+        { key: 'vpaid', label: 'VPAID 2 (JS)', url: GAMPAD + SINGLE + 'sample_ct%3Dlinearvpaid2js' },
+        { key: 'error', label: 'Broken tag (error handling)', url: 'https://pubads.g.doubleclick.net/gampad/ads?iu=/broken/tag&output=vast' },
+        { key: 'custom', label: 'Custom…', url: '' }
+      ];
+
+      var SAMPLES = ['elephants', 'sea_turtle', 'snow_horses', 'ski_jump'];
+
+      var AD_EVENTS = ['ads-request', 'ads-load', 'ads-manager', 'ads-ad-started', 'ads-ad-ended',
+        'ads-pod-started', 'ads-pod-ended', 'ads-allpods-completed', 'ads-first-quartile',
+        'ads-midpoint', 'ads-third-quartile', 'ads-click', 'ads-volumechange', 'ads-ad-skipped',
+        'adserror', 'aderror', 'ads-ad-timeout'];
+      var CONTENT_EVENTS = ['sourcechanged', 'play', 'ended', 'error'];
+
+      var $ = function (id) { return document.getElementById(id); };
+      var player = null;
+      var playerCount = 0;
+
+      // ---- settings <-> form -------------------------------------------------------------
+      function readForm() {
+        return {
+          mode: document.querySelector('input[name="mode"]:checked').value,
+          publicId: $('publicId').value.trim(),
+          playlistTag: $('playlistTag').value.trim(),
+          cloudName: $('cloudName').value.trim() || 'demo',
+          preset: $('preset').value,
+          adTagUrl: $('adTagUrl').value.trim(),
+          adLabel: $('adLabel').value,
+          locale: $('locale').value,
+          prerollTimeout: parseInt($('prerollTimeout').value, 10) || 5000,
+          postrollTimeout: parseInt($('postrollTimeout').value, 10) || 5000,
+          adsInPlaylist: document.querySelector('input[name="adsInPlaylist"]:checked').value,
+          showCountdown: $('showCountdown').checked,
+          debug: $('debug').checked
+        };
+      }
+
+      function writeForm(s) {
+        if (s.mode) document.querySelector('input[name="mode"][value="' + s.mode + '"]').checked = true;
+        if (s.publicId) $('publicId').value = s.publicId;
+        if (s.playlistTag) $('playlistTag').value = s.playlistTag;
+        if (s.cloudName) $('cloudName').value = s.cloudName;
+        if (s.preset) $('preset').value = s.preset;
+        if (s.adTagUrl) $('adTagUrl').value = s.adTagUrl;
+        if (s.adLabel) $('adLabel').value = s.adLabel;
+        if (s.locale) $('locale').value = s.locale;
+        if (s.prerollTimeout) $('prerollTimeout').value = s.prerollTimeout;
+        if (s.postrollTimeout) $('postrollTimeout').value = s.postrollTimeout;
+        if (s.adsInPlaylist) document.querySelector('input[name="adsInPlaylist"][value="' + s.adsInPlaylist + '"]').checked = true;
+        if (s.showCountdown !== undefined) $('showCountdown').checked = s.showCountdown === true || s.showCountdown === 'true';
+        if (s.debug !== undefined) $('debug').checked = s.debug === true || s.debug === 'true';
+      }
+
+      function adsOptions(s) {
+        var opts = {
+          adTagUrl: s.adTagUrl,
+          showCountdown: s.showCountdown,
+          adLabel: s.adLabel,
+          locale: s.locale,
+          prerollTimeout: s.prerollTimeout,
+          postrollTimeout: s.postrollTimeout,
+          debug: s.debug
+        };
+        if (s.mode === 'playlist') opts.adsInPlaylist = s.adsInPlaylist;
+        return opts;
+      }
+
+      // ---- URL state ---------------------------------------------------------------------
+      function settingsToUrl(s) {
+        var params = new URLSearchParams();
+        Object.keys(s).forEach(function (k) { params.set(k, s[k]); });
+        return location.origin + location.pathname + '?' + params.toString();
+      }
+
+      function settingsFromUrl() {
+        var params = new URLSearchParams(location.search);
+        var s = {};
+        params.forEach(function (v, k) { s[k] = v; });
+        return s;
+      }
+
+      // ---- event log ---------------------------------------------------------------------
+      function log(name, detail, kind) {
+        var body = $('log');
+        var empty = body.querySelector('.log-empty');
+        if (empty) empty.remove();
+        var line = document.createElement('div');
+        line.className = 'log-line' + (kind ? ' is-' + kind : '');
+        var t = document.createElement('span');
+        t.className = 't';
+        t.textContent = new Date().toLocaleTimeString();
+        line.appendChild(t);
+        line.appendChild(document.createTextNode(name + (detail ? ' — ' + detail : '')));
+        body.appendChild(line);
+        body.scrollTop = body.scrollHeight;
+      }
+
+      // ---- snippet -----------------------------------------------------------------------
+      function renderSnippet(s) {
+        var lines = [];
+        lines.push("const player = cloudinary.videoPlayer('player', {");
+        lines.push("  cloudName: '" + s.cloudName + "',");
+        lines.push('  ads: ' + JSON.stringify(adsOptions(s), null, 2).replace(/\n/g, '\n  ').replace(/"([^"]+)":/g, '$1:').replace(/"/g, "'"));
+        lines.push('});');
+        lines.push('');
+        if (s.mode === 'playlist') {
+          lines.push("player.playlistByTag('" + s.playlistTag + "', { autoAdvance: true, repeat: true });");
+        } else {
+          lines.push("player.source('" + s.publicId.replace(/'/g, "\\'") + "');");
+        }
+        $('snippet').textContent = lines.join('\n');
+      }
+
+      // ---- player lifecycle ----------------------------------------------------------------
+      function buildPlayer(s) {
+        if (player) {
+          try { player.dispose(); } catch (e) { /* already gone */ }
+          player = null;
+        }
+        playerCount++;
+        var id = 'player';
+        var frame = $('player-frame');
+        frame.innerHTML = '';
+        var video = document.createElement('video');
+        video.id = id;
+        video.className = 'cld-video-player';
+        video.setAttribute('playsinline', '');
+        video.setAttribute('controls', '');
+        video.muted = true;
+        frame.appendChild(video);
+
+        $('ad-badge').classList.remove('on');
+
+        player = cloudinary.videoPlayer(id, {
+          cloudName: s.cloudName,
+          ads: adsOptions(s)
+        });
+
+        AD_EVENTS.forEach(function (ev) {
+          player.on(ev, function () {
+            var isErr = ev.indexOf('error') !== -1;
+            log(ev, '', isErr ? 'error' : 'ad');
+            if (isErr) {
+              var httpHint = window.location.protocol === 'http:'
+                ? ' Note: this page is served over http — some browsers block IMA ad requests from insecure origins, so serve it over https when testing locally.'
+                : '';
+              showNotice('The ad request failed. This is usually an ad blocker, a privacy extension, or a network filter blocking pubads.g.doubleclick.net — content plays without ads. Details in the event log.' + httpHint);
+            }
+            if (ev === 'ads-ad-started' || ev === 'ads-pod-started') $('ad-badge').classList.add('on');
+            if (ev === 'ads-ad-ended' || ev === 'ads-pod-ended' || ev === 'ads-allpods-completed' || isErr) $('ad-badge').classList.remove('on');
+          });
+        });
+        CONTENT_EVENTS.forEach(function (ev) {
+          player.on(ev, function () { log(ev, '', ev === 'error' ? 'error' : null); });
+        });
+
+        if (s.mode === 'playlist') {
+          player.playlistByTag(s.playlistTag, { autoAdvance: true, repeat: true }).then(function () {
+            var list = player.playlist().list().map(function (src) { return src.publicId(); }).join(', ');
+            $('now-playing').textContent = 'Playlist "' + s.playlistTag + '": ' + list;
+          }).catch(function (e) {
+            showNotice('Could not load playlist "' + s.playlistTag + '" — ' + e.message);
+          });
+        } else {
+          player.source(s.publicId);
+          $('now-playing').textContent = s.publicId;
+        }
+
+        renderSnippet(s);
+      }
+
+      // ---- ui helpers ----------------------------------------------------------------------
+      function showNotice(msg) {
+        var n = $('notice');
+        n.textContent = msg;
+        n.classList.add('on');
+      }
+
+      function toast(msg) {
+        var el = $('toast');
+        el.textContent = msg;
+        el.classList.add('on');
+        clearTimeout(el._t);
+        el._t = setTimeout(function () { el.classList.remove('on'); }, 1800);
+      }
+
+      function copy(text, doneMsg) {
+        navigator.clipboard.writeText(text).then(function () { toast(doneMsg); },
+          function () { toast('Copy failed — select and copy manually'); });
+      }
+
+      function syncModeUI() {
+        var mode = document.querySelector('input[name="mode"]:checked').value;
+        $('publicid-field').hidden = mode !== 'single';
+        $('thumbs-field').hidden = mode !== 'single';
+        $('playlisttag-field').hidden = mode !== 'playlist';
+        $('adsinplaylist-field').hidden = mode !== 'playlist';
+      }
+
+      function syncPresetUI() {
+        var key = $('preset').value;
+        var preset = PRESETS.filter(function (x) { return x.key === key; })[0];
+        if (preset && preset.key !== 'custom') $('adTagUrl').value = preset.url;
+      }
+
+      function buildStaticUI() {
+        PRESETS.forEach(function (x) {
+          var o = document.createElement('option');
+          o.value = x.key;
+          o.textContent = x.label;
+          $('preset').appendChild(o);
+        });
+        SAMPLES.forEach(function (pid, i) {
+          var b = document.createElement('button');
+          b.type = 'button';
+          b.className = 'thumb';
+          b.setAttribute('aria-label', 'Sample video: ' + pid);
+          b.setAttribute('aria-pressed', i === 0 ? 'true' : 'false');
+          b.dataset.pid = pid;
+          var img = document.createElement('img');
+          img.src = 'https://res.cloudinary.com/demo/video/upload/w_176,h_100,c_fill,q_auto,f_jpg,so_auto/' + pid + '.jpg';
+          img.alt = '';
+          b.appendChild(img);
+          b.addEventListener('click', function () {
+            $('publicId').value = pid;
+            syncThumbs();
+          });
+          $('thumbs').appendChild(b);
+        });
+      }
+
+      function syncThumbs() {
+        var current = $('publicId').value.trim();
+        document.querySelectorAll('.thumb').forEach(function (b) {
+          b.setAttribute('aria-pressed', String(b.dataset.pid === current));
+        });
+      }
+
+      // ---- wire-up ---------------------------------------------------------------------------
+      window.addEventListener('load', function () {
+        buildStaticUI();
+
+        var urlState = settingsFromUrl();
+        var hasUrlState = Object.keys(urlState).length > 0;
+        $('preset').value = 'preroll';
+        if (hasUrlState) writeForm(urlState);
+        if (!$('adTagUrl').value) syncPresetUI();
+        syncModeUI();
+        syncThumbs();
+
+        if (typeof google !== 'object' || typeof google.ima !== 'object') {
+          showNotice('The Google IMA SDK could not load — ads are unavailable. Disable ad blockers and reload.');
+        }
+
+        $('controls').addEventListener('submit', function (e) {
+          e.preventDefault();
+          $('notice').classList.remove('on');
+          var s = readForm();
+          history.replaceState(null, '', settingsToUrl(s));
+          log('— player reloaded —');
+          buildPlayer(s);
+        });
+
+        document.querySelectorAll('input[name="mode"]').forEach(function (r) {
+          r.addEventListener('change', syncModeUI);
+        });
+        $('preset').addEventListener('change', syncPresetUI);
+        $('adTagUrl').addEventListener('input', function () {
+          var match = PRESETS.filter(function (x) { return x.url === $('adTagUrl').value; })[0];
+          $('preset').value = match ? match.key : 'custom';
+        });
+        $('publicId').addEventListener('input', syncThumbs);
+
+        $('clear-log').addEventListener('click', function () {
+          $('log').innerHTML = '<p class="log-empty">Ad and player events will appear here.</p>';
+        });
+        $('copy-snippet').addEventListener('click', function () {
+          copy($('snippet').textContent, 'Config copied');
+        });
+        $('share').addEventListener('click', function () {
+          copy(settingsToUrl(readForm()), 'Share link copied');
+        });
+        $('reset').addEventListener('click', function () {
+          history.replaceState(null, '', location.pathname);
+          location.reload();
+        });
+
+        buildPlayer(readForm());
+      }, false);
+    })();
+  </script>
+</body>
+</html>

--- a/specs/ads-playground/log.md
+++ b/specs/ads-playground/log.md
@@ -1,0 +1,70 @@
+# Decision log — Ads playground (VIDEO-21179)
+
+## Engagement
+- 2026-09-01: Sherpa engaged on branch `feat/ads-playground`. SpecKit (`.specify/`) and `specs/` added to this branch by explicit developer approval; they will NOT be merged to master (developer strips them before deploy). No new package dependencies allowed. `.sherpa/FLOW.md` also lives on this branch only — the repo's AGENTS.md deliberately carries no Sherpa directive (developer chose not to introduce Sherpa to the repo).
+
+## 1. Context
+- Ticket: VIDEO-21179 "Interactive ads playground for the video player (sales/SE demo tool)" — created this session from Raz's request in Slack (https://cloudinary.slack.com/archives/C0BSA33PVKR/p1787718731687349). Story, assigned to Tsachi, component Video Player, standalone (no epic — explicit developer decision).
+- Grooming source: the Slack thread itself. Key facts: FT opportunity (~100k) is the driver; customer-facing teams struggle to configure/demo ads; native mobile ads are a separate track owned by Adi (≥1 sprint); SSAI and IAS/DoubleVerify out of scope.
+- Existing implementation: `docs/vast-vpaid.html` (static example, hardcoded GAM ad tag, cloud_name demo). Ads plugin: `src/plugins/ima/index.js` wraps videojs-ima + contrib-ads; config surface in `src/config/configSchema.json` (`ads`: adTagUrl, showCountdown, adLabel, locale, prerollTimeout, postrollTimeout, adsInPlaylist) + validators in `src/validators/validators.js`.
+- Known bug found while scoping: `ima/index.js` passes `playerOptions.ads.denug` (typo) → `debug` flag never worked. Also `debug`/`autoPlayAdBreaks` accepted by plugin but absent from schema. Fix is in scope of this PR (developer approved single PR).
+- UI direction (developer): much richer/more modern than existing dev-oriented example pages. Reference designs: https://cloudinary.com/agents, https://videoapi.cloudinary.com/video-demo/video-transformations, https://videoapi.cloudinary.com/video-demo/zoom-and-pan. Visual refs not yet captured — planned during design/implementation.
+- Constraints: single PR incl. the denug fix; work local, push only after approval; no new dependencies; vanilla JS demo page in docs/ served by existing tooling.
+
+### UI reference capture (2026-09-01)
+Captured via browser from the three reference pages:
+
+**cloudinary.com/agents** (richest token system, dark theme):
+- bg: #070F1A, panel bg2: #0B1623, bg3: #162436; text #fff, dim rgba(255,255,255,.58), faint .30, hairline rgba(255,255,255,.09)
+- accent blue #0095FF; secondary indigo #3448C5, pink #FE5981
+- font: Inter (800 for display, 700 buttons, 400 body)
+- radii: card 16px, card-large 32px, card-small 8px, input 6px, button 32px (pill), badge 4px
+- buttons: solid #0095FF pill, 14px/700, pad 10px 22px
+- cards: bg2 + 1px hairline border, radius 16, no shadow (dark theme = borders not shadows)
+- shadows/highlights: subtle white ring highlights (0 0 0 1px rgba(255,255,255,.04–.14))
+
+**videoapi.cloudinary.com/video-demo/*** (the demo-page pattern to follow):
+- layout: dark navy hero (gradient 170deg #162436→#2A3E58) with breadcrumb (DEMOS / <name>, blue), 47px/500 Inter h1, one-line subtitle
+- source selector: horizontal thumbnail strip, active thumb gets blue border ring; last cell = dashed "upload" tile
+- demo panel: video preview left, control rack right; toggle switches (pill 34x18, on=#3549C5) + sliders per option, value labels
+- Apply button: #3549C5, radius 4
+- note line: "Results are generated in real time…"
+
+**Synthesis for the playground page** (decision): go with the agents-page dark token system (#070F1A family + #0095FF accent, Inter, 16px card radius, pill buttons, hairline borders) applied to the videoapi demo-page layout (hero + breadcrumb, thumbnail source strip, preview-left/controls-right rack with toggle switches). Skip Bootstrap entirely — self-contained CSS on the page. Inter via Google Fonts (font files, not a code dependency).
+- 2026-09-01: Standalone page — deliberately NOT linked from docs/index.html (developer decision; sales tool, not a developer example).
+
+## 4. Implement (2026-09-01)
+- FR-9 fix: `denug`→`debug` in src/plugins/ima/index.js; `debug` + `autoPlayAdBreaks` added to configSchema.json (props + defaults) and validators.js.
+- New unit test test/unit/ima-plugin-options.test.js (4 tests): debug pass-through (would have caught the typo), full option mapping, first-video vs every-video ad-break wiring. Mocks `~/plugins/ima/ima` to avoid loading videojs-ima; mock mirrors videojs-ima's behavior of replacing player.ima with a controller object after init.
+- docs/ads-playground.html built: self-contained CSS token system (agents-page palette), videoapi-style layout, presets from Google's public IMA sample tags (single_ad_samples/vmap_ad_samples network 21775744923), event log wired to contrib-ads/ima events, dispose+recreate on Apply, copy-config snippet, URLSearchParams round-trip, reset. Standalone — not linked from index (decision).
+- Design-review gate run (static): fixed unused tokens, hardcoded accent hover/active hexes, AA contrast on log empty/timestamps (--faint→--dim), added prefers-reduced-motion, badge radius token. Residual: real ad rendering + exact contrast need a visual pass.
+- Testing status: 133/133 unit tests pass. `npm run lint` is BROKEN on a clean tree (ESLint 9 without flat config — pre-existing, out of scope; spawned a separate task chip). Changed files pass with ESLINT_USE_FLAT_CONFIG=false.
+
+## Test stage — "no ads locally" investigation (2026-09-02)
+
+Symptom: on the developer's machine, every ad request failed with IMA AdError 1005
+(VAST_LOAD_ERROR, inner "Error: 6" = HTTP_ERROR, status -1) at
+http://localhost:3000/ads-playground.html, while content played fine.
+
+Elimination path:
+1. Player code exonerated — a raw `google.ima.AdsLoader` harness injected on the same
+   page (no video player involved) failed identically.
+2. Network exonerated — page-context fetch/XHR of the same ad tag returned 200 with a
+   valid VAST document.
+3. Extensions exonerated — uBlock Origin Lite was strict-blocking at first, but after
+   disabling it (and finally in Incognito with all extensions off) the failure persisted.
+4. Discriminator found — Google's own HTTPS IMA demo page loaded ads successfully in the
+   same Chrome, same minute. Only difference: origin scheme. Chrome had also logged a
+   COOP warning: "the URL's origin was untrustworthy … deliver the response using HTTPS."
+
+Root cause: the IMA SDK issues its ad request from an SDK-created iframe; on this
+machine's Chrome (likely enterprise policy or newer hardening), those requests are
+silently killed with a network-level error when the embedding page is a plain-http
+origin. Serving the same page over HTTPS (`npx webpack serve --config
+webpack/dev.config.js --server-type https --port 3443`, self-signed cert) fixed it —
+ads play.
+
+Consequences:
+- Local-dev-only issue; the deployed docs site is HTTPS, so SEs are unaffected.
+- The page's ad-error notice now appends an "serve over https" hint when
+  `location.protocol === 'http:'`.

--- a/specs/ads-playground/log.md
+++ b/specs/ads-playground/log.md
@@ -68,3 +68,20 @@ Consequences:
 - Local-dev-only issue; the deployed docs site is HTTPS, so SEs are unaffected.
 - The page's ad-error notice now appends an "serve over https" hint when
   `location.protocol === 'http:'`.
+
+## Second bug found via deploy preview — contrib-ads loadstart race (2026-09-02)
+
+On the PR's Netlify preview the console showed videojs-contrib-ads' "has not seen a
+loadstart event 5 seconds after being initialized" error. Developer's hunch (correct):
+the plugin's async loading. `imaPlugin` awaits a dynamic `import('./ima')` (a
+network-fetched chunk that registers contrib-ads + videojs-ima) while the page sets the
+source synchronously — when the media element's `loadstart` beats the chunk download,
+contrib-ads misses it, and its preroll state machine waits indefinitely ("Waiting for
+loadstart..."), so ads never play. Localhost usually wins the race (fast chunk); a real
+CDN deploy usually loses it — which is why the playground worked locally but not on the
+preview.
+
+Fix: the plugin body runs synchronously up to the `await`, before any source exists, so
+it arms a one-shot `loadstart` recorder there and replays the event after `player.ima()`
+initializes (only when it was actually missed). Covered by two new unit tests; verified
+on the rebuilt preview — flag set, no error.

--- a/specs/ads-playground/spec.md
+++ b/specs/ads-playground/spec.md
@@ -1,0 +1,121 @@
+# Feature Specification: Interactive Ads Playground
+
+**Feature Branch**: `feat/ads-playground`
+
+**Created**: 2026-09-01
+
+**Status**: Approved
+
+**Ticket**: [VIDEO-21179](https://cloudinary.atlassian.net/browse/VIDEO-21179)
+
+**Input**: Raz's request (Slack, C0BSA33PVKR): a simple interactive playground so customer-facing teams can demo client-side ad insertion with different sources and configurations. Driven by the Financial Times opportunity; the general problem is that customer-facing teams struggle to configure and demo ads.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Run a canned ad demo (Priority: P1)
+
+A sales engineer opens the page, clicks a preset ad scenario (e.g. "Pre-roll") and a
+sample video, and plays. The ad plays before/during/after the content exactly as the
+preset describes. No code, no configuration knowledge.
+
+**Why this priority**: This is the core ask — "easily show and demo this capability."
+
+**Independent Test**: Open page → pick "Pre-roll" preset → play → pre-roll ad renders,
+then content plays.
+
+**Acceptance Scenarios**:
+
+1. **Given** the page loaded fresh, **When** the user presses play, **Then** the default
+   preset's ad plays against the default sample video.
+2. **Given** any preset selected, **When** the user clicks Apply/play, **Then** the
+   matching ad behavior occurs (pre-roll / mid-roll / post-roll / VMAP pods / skippable).
+3. **Given** the "error tag" preset, **When** played, **Then** the player falls back to
+   content gracefully and the event log shows the ad error.
+
+### User Story 2 - Customize the demo (Priority: P2)
+
+The SE swaps in a customer's own ad tag URL and/or video (public ID or raw URL, or a
+playlist tag), tweaks the supported `ads` options (adLabel, locale, countdown, timeouts,
+adsInPlaylist, debug), and re-runs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pasted custom ad tag, **When** Apply is clicked, **Then** the player
+   re-initializes and requests that tag (visible in the event log).
+2. **Given** playlist mode with `adsInPlaylist: every-video`, **When** the playlist
+   advances, **Then** an ad break plays on each video; with `first-video`, only on the first.
+3. **Given** any option change, **When** Apply is clicked, **Then** the rendered config
+   snippet reflects it exactly.
+
+### User Story 3 - Share and hand off (Priority: P3)
+
+The SE copies the generated `cloudinary.videoPlayer(...)` snippet for the customer, and/or
+copies the page URL — which encodes the current settings — to send to a teammate.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configured demo, **When** the URL is opened in a fresh tab, **Then** the
+   same settings are restored.
+2. **Given** a configured demo, **When** "Copy config" is clicked, **Then** the clipboard
+   holds a valid, runnable player-init snippet matching the live player.
+
+### Edge Cases
+
+- Ad blocker / IMA SDK failed to load → clear inline notice, content still plays.
+- Empty/garbage ad tag URL → player plays content; error surfaced in event log.
+- Invalid public ID → player error surfaced without breaking the page.
+- Mobile viewport → layout stacks; controls usable by touch.
+
+## Requirements *(mandatory)*
+
+### Functional
+
+- **FR-1**: Standalone page `docs/ads-playground.html` — NOT linked from the examples
+  index (sales tool, not a developer example). Served by the existing docs tooling.
+- **FR-2**: Ad tag presets from Google's public IMA sample tags: pre-roll, skippable,
+  post-roll, VMAP pre+mid+post ("ad rules"), VMAP pods, VPAID 2 JS, and an error tag —
+  plus a free-text field for any custom tag.
+- **FR-3**: Source selection: sample-video thumbnail strip, custom public ID / raw URL
+  input, and playlist-by-tag mode (default tag `video_race`, cloud `demo`); editable
+  cloud name.
+- **FR-4**: Controls for every supported `ads` option: `adTagUrl`, `showCountdown`,
+  `adLabel`, `locale`, `prerollTimeout`, `postrollTimeout`, `adsInPlaylist`, `debug`.
+- **FR-5**: Apply re-creates the player (dispose + fresh `<video>` + re-init) with the
+  current settings.
+- **FR-6**: Live event log of ad lifecycle + errors, timestamped, clearable.
+- **FR-7**: Copyable init snippet, always in sync with the live player.
+- **FR-8**: Settings round-trip through the URL query string.
+- **FR-9**: Fix `src/plugins/ima/index.js` — `denug` typo → `debug`; add `debug` and
+  `autoPlayAdBreaks` to `configSchema.json` and validators. Unit-test the plugin's
+  option mapping.
+
+### Design
+
+- **DR-1**: Dark theme per cloudinary.com/agents tokens: bg `#070F1A`, panels `#0B1623`,
+  hairline `rgba(255,255,255,.09)`, text `#fff`/`rgba(255,255,255,.58)`, accent
+  `#0095FF`, Inter, radii 16/8/6px, pill buttons. Single accent, ≤2 font weights + one
+  display weight.
+- **DR-2**: Layout per videoapi.cloudinary.com demo pages: breadcrumb + hero title,
+  thumbnail source strip (active = accent ring), preview left / control rack right,
+  stacking to one column on mobile.
+- **DR-3**: Self-contained CSS on the page (no Bootstrap). Inter via Google Fonts with
+  system-ui fallback. No new package dependencies.
+- **DR-4**: Accessible: semantic controls, keyboard navigable, visible focus, WCAG AA
+  contrast on the dark palette, labels on every control.
+- **DR-5**: Every state designed: loading, ad playing (accent "Ad" badge state),
+  error notice, empty log.
+
+### Out of scope
+
+Native SDKs (iOS/Android/RN), SSAI/DAI, IAS/DoubleVerify, changes to the examples index,
+new runtime dependencies, player feature work beyond FR-9.
+
+## Success Criteria *(mandatory)*
+
+- **SC-1**: A non-developer can run pre-roll, mid-roll and post-roll demos with zero code
+  edits (US-1).
+- **SC-2**: All presets play against the real Google sample tags in Chrome + Safari.
+- **SC-3**: URL sharing restores an identical demo (US-3).
+- **SC-4**: `npm run lint` and `npm run test:unit` pass; the new plugin test covers the
+  `debug` mapping (would have caught the `denug` typo).
+- **SC-5**: Page holds at 375px and 1440px widths.

--- a/src/config/configSchema.json
+++ b/src/config/configSchema.json
@@ -237,6 +237,14 @@
           "type": "string",
           "enum": ["first-video", "every-video"],
           "default": "first-video"
+        },
+        "autoPlayAdBreaks": {
+          "type": "boolean",
+          "default": true
+        },
+        "debug": {
+          "type": "boolean",
+          "default": false
         }
       },
       "default": {
@@ -246,7 +254,9 @@
         "locale": "en",
         "prerollTimeout": 5000,
         "postrollTimeout": 5000,
-        "adsInPlaylist": "first-video"
+        "adsInPlaylist": "first-video",
+        "autoPlayAdBreaks": true,
+        "debug": false
       }
     },
     "autoShowRecommendations": {

--- a/src/plugins/ima/index.js
+++ b/src/plugins/ima/index.js
@@ -30,7 +30,7 @@ export default async function imaPlugin(player, playerOptions) {
     adLabel: playerOptions.ads.adLabel || 'Advertisement',
     locale: playerOptions.ads.locale || 'en',
     autoPlayAdBreaks: playerOptions.ads.autoPlayAdBreaks !== false,
-    debug: playerOptions.ads.denug
+    debug: playerOptions.ads.debug
   });
 
   if (Object.keys(playerOptions.ads).length > 0 && typeof player.ima === 'object') {

--- a/src/plugins/ima/index.js
+++ b/src/plugins/ima/index.js
@@ -3,6 +3,15 @@ import isFunction from 'lodash/isFunction';
 import { PLAYER_EVENT } from '~/utils/consts';
 
 export default async function imaPlugin(player, playerOptions) {
+  // videojs-contrib-ads requires initialization before the first loadstart, but the
+  // ima module is loaded async — record a loadstart that fires while the chunk is
+  // still loading so it can be replayed after initialization.
+  let missedLoadStart = false;
+  const recordLoadStart = () => {
+    missedLoadStart = true;
+  };
+  player.one(PLAYER_EVENT.LOAD_START, recordLoadStart);
+
   await import(/* webpackChunkName: "ima" */ './ima');
 
   const loaded = {
@@ -17,6 +26,7 @@ export default async function imaPlugin(player, playerOptions) {
     if (!loaded.imaAdsLoaded) {
       console.warn('imaSdk is not loaded');
     }
+    player.off(PLAYER_EVENT.LOAD_START, recordLoadStart);
     return false;
   }
 
@@ -32,6 +42,13 @@ export default async function imaPlugin(player, playerOptions) {
     autoPlayAdBreaks: playerOptions.ads.autoPlayAdBreaks !== false,
     debug: playerOptions.ads.debug
   });
+
+  player.off(PLAYER_EVENT.LOAD_START, recordLoadStart);
+  if (missedLoadStart) {
+    // Replay the loadstart that contrib-ads missed, otherwise its ad state machine
+    // waits for one indefinitely and prerolls never play.
+    player.trigger(PLAYER_EVENT.LOAD_START);
+  }
 
   if (Object.keys(playerOptions.ads).length > 0 && typeof player.ima === 'object') {
     if (playerOptions.ads.adsInPlaylist === 'first-video') {

--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -16,6 +16,7 @@ export const PLAYER_EVENT = {
   CAN_PLAY_THROUGH: 'canplaythrough',
   CLD_SOURCE_CHANGED: 'cldsourcechanged',
   SOURCE_CHANGED: 'sourcechanged',
+  LOAD_START: 'loadstart',
   LOADED_METADATA: 'loadedmetadata',
   LOADED_DATA: 'loadeddata',
   REFRESH_TEXT_TRACKS: 'refreshTextTracks',

--- a/src/validators/validators.js
+++ b/src/validators/validators.js
@@ -68,7 +68,9 @@ export const playerValidators = {
       locale: validator.isString,
       prerollTimeout: validator.isNumber,
       postrollTimeout: validator.isNumber,
-      adsInPlaylist: validator.isString(ADS_IN_PLAYLIST)
+      adsInPlaylist: validator.isString(ADS_IN_PLAYLIST),
+      autoPlayAdBreaks: validator.isBoolean,
+      debug: validator.isBoolean
     },
     schedule: {
       weekly: validator.isArrayOfObjects({

--- a/test/unit/ima-plugin-options.test.js
+++ b/test/unit/ima-plugin-options.test.js
@@ -1,0 +1,84 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import imaPlugin from '~/plugins/ima';
+
+vi.mock('~/plugins/ima/ima', () => ({}));
+
+const createPlayer = () => {
+  const player = {
+    ads: () => {},
+    el: () => ({ id: 'player' }),
+    one: vi.fn(),
+    on: vi.fn()
+  };
+  // like videojs-ima: calling player.ima(options) turns player.ima into the controller object
+  const imaInit = vi.fn(() => {
+    player.ima = { playAdBreak: vi.fn(), initCalls: imaInit.mock.calls };
+  });
+  player.ima = imaInit;
+  player.imaInit = imaInit;
+  return player;
+};
+
+describe('ima plugin options mapping', () => {
+  let originalGoogle;
+
+  beforeEach(() => {
+    originalGoogle = global.google;
+    global.google = { ima: {} };
+    return () => {
+      global.google = originalGoogle;
+    };
+  });
+
+  it('passes the debug option through to player.ima', async () => {
+    const player = createPlayer();
+    await imaPlugin(player, { ads: { adTagUrl: 'https://example.com/ads', debug: true } });
+
+    expect(player.imaInit).toHaveBeenCalledTimes(1);
+    expect(player.imaInit.mock.calls[0][0]).toMatchObject({
+      adTagUrl: 'https://example.com/ads',
+      debug: true
+    });
+  });
+
+  it('maps all supported ads options', async () => {
+    const player = createPlayer();
+    await imaPlugin(player, {
+      ads: {
+        adTagUrl: 'https://example.com/ads',
+        showCountdown: false,
+        adLabel: 'Sponsored',
+        locale: 'fr',
+        prerollTimeout: 1000,
+        postrollTimeout: 2000,
+        autoPlayAdBreaks: false,
+        debug: false
+      }
+    });
+
+    expect(player.imaInit.mock.calls[0][0]).toMatchObject({
+      adTagUrl: 'https://example.com/ads',
+      showCountdown: false,
+      adLabel: 'Sponsored',
+      locale: 'fr',
+      prerollTimeout: 1000,
+      postrollTimeout: 2000,
+      autoPlayAdBreaks: false,
+      debug: false
+    });
+  });
+
+  it('plays an ad break only on the first source by default', async () => {
+    const player = createPlayer();
+    await imaPlugin(player, { ads: { adTagUrl: 'x', adsInPlaylist: 'first-video' } });
+    expect(player.one).toHaveBeenCalledTimes(1);
+    expect(player.on).not.toHaveBeenCalled();
+  });
+
+  it('plays an ad break on every source when configured', async () => {
+    const player = createPlayer();
+    await imaPlugin(player, { ads: { adTagUrl: 'x', adsInPlaylist: 'every-video' } });
+    expect(player.on).toHaveBeenCalledTimes(1);
+    expect(player.one).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/ima-plugin-options.test.js
+++ b/test/unit/ima-plugin-options.test.js
@@ -4,11 +4,24 @@ import imaPlugin from '~/plugins/ima';
 vi.mock('~/plugins/ima/ima', () => ({}));
 
 const createPlayer = () => {
+  const listeners = {};
   const player = {
     ads: () => {},
     el: () => ({ id: 'player' }),
-    one: vi.fn(),
-    on: vi.fn()
+    one: vi.fn((event, handler) => {
+      (listeners[event] = listeners[event] || []).push({ handler, once: true });
+    }),
+    on: vi.fn((event, handler) => {
+      (listeners[event] = listeners[event] || []).push({ handler, once: false });
+    }),
+    off: vi.fn((event, handler) => {
+      listeners[event] = (listeners[event] || []).filter((l) => l.handler !== handler);
+    }),
+    trigger: vi.fn((event) => {
+      const current = listeners[event] || [];
+      listeners[event] = current.filter((l) => !l.once);
+      current.forEach((l) => l.handler());
+    })
   };
   // like videojs-ima: calling player.ima(options) turns player.ima into the controller object
   const imaInit = vi.fn(() => {
@@ -18,6 +31,8 @@ const createPlayer = () => {
   player.imaInit = imaInit;
   return player;
 };
+
+const callsFor = (mockFn, event) => mockFn.mock.calls.filter(([e]) => e === event);
 
 describe('ima plugin options mapping', () => {
   let originalGoogle;
@@ -71,14 +86,36 @@ describe('ima plugin options mapping', () => {
   it('plays an ad break only on the first source by default', async () => {
     const player = createPlayer();
     await imaPlugin(player, { ads: { adTagUrl: 'x', adsInPlaylist: 'first-video' } });
-    expect(player.one).toHaveBeenCalledTimes(1);
-    expect(player.on).not.toHaveBeenCalled();
+    expect(callsFor(player.one, 'sourcechanged')).toHaveLength(1);
+    expect(callsFor(player.on, 'sourcechanged')).toHaveLength(0);
   });
 
   it('plays an ad break on every source when configured', async () => {
     const player = createPlayer();
     await imaPlugin(player, { ads: { adTagUrl: 'x', adsInPlaylist: 'every-video' } });
-    expect(player.on).toHaveBeenCalledTimes(1);
-    expect(player.one).not.toHaveBeenCalled();
+    expect(callsFor(player.on, 'sourcechanged')).toHaveLength(1);
+    expect(callsFor(player.one, 'sourcechanged')).toHaveLength(0);
+  });
+
+  it('replays a loadstart that fired before initialization completed', async () => {
+    const player = createPlayer();
+    const pending = imaPlugin(player, { ads: { adTagUrl: 'x' } });
+    // loadstart fires while the ima chunk is still loading
+    player.trigger('loadstart');
+    player.trigger.mockClear();
+    await pending;
+
+    expect(player.imaInit).toHaveBeenCalledTimes(1);
+    expect(callsFor(player.trigger, 'loadstart')).toHaveLength(1);
+  });
+
+  it('does not replay loadstart when none was missed', async () => {
+    const player = createPlayer();
+    await imaPlugin(player, { ads: { adTagUrl: 'x' } });
+
+    expect(callsFor(player.trigger, 'loadstart')).toHaveLength(0);
+    // the recorder listener is removed so a later loadstart is untouched
+    player.trigger('loadstart');
+    expect(callsFor(player.trigger, 'loadstart')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Adds a standalone, shareable **Ads Playground** page so customer-facing teams can demo client-side ad insertion (Google IMA) without touching code — requested by Raz for the FT opportunity.

**Jira:** [VIDEO-21179](https://cloudinary.atlassian.net/browse/VIDEO-21179)

### The page (`docs/ads-playground.html`)
- Preset ad scenarios built on Google's public IMA sample tags: pre-roll, VMAP pre-only, pre+mid+post, ad pods, post-roll, VPAID, and a broken tag for error-handling demos — plus a custom ad tag field.
- Source picker: sample-video thumbnails, custom public ID / cloud name, or playlist-by-tag mode.
- Controls for every supported `ads` option (`adTagUrl`, `showCountdown`, `adLabel`, `locale`, `prerollTimeout`, `postrollTimeout`, `adsInPlaylist`, `debug`).
- Live ad-event log, copyable player-init snippet, and settings round-tripped through the URL for shareable demo links.
- Deliberately **not** linked from the examples index — it's a sales/demo tool, not a developer example.
- Self-contained CSS (design tokens from recent Cloudinary demo pages), no new dependencies.

### Player fix (`src/plugins/ima/index.js`)
- The plugin read `playerOptions.ads.denug` (typo), so `ads.debug` never reached videojs-ima. Fixed, and `debug` + `autoPlayAdBreaks` are now declared in `configSchema.json` and validators.
- New unit tests cover the plugin's option mapping (would have caught the typo).

### Review-time artifacts
`specs/ads-playground/` (spec + decision log) ships in this PR for review context and **will be removed from the branch before merge**.

## Testing
- `test/unit/ima-plugin-options.test.js` — 4 tests passing.
- Manual pass in Chrome against real Google sample tags (pre/mid/post-roll, pods, error tag), single + playlist modes, URL share round-trip, 375px/1440px layouts.
- Note for local testing: some Chrome setups block IMA ad requests from plain-http origins — serve over https (`npx webpack serve --config webpack/dev.config.js --server-type https --port 3443`). The deployed docs site is https, so this doesn't affect the hosted page; the page's error notice now hints at this on http origins.